### PR TITLE
feat: v2 HTTP transport — Client and Collection implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,9 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <junit-version>4.13.2</junit-version>
+        <jacoco.version>0.8.12</jacoco.version>
+        <pitest.version>1.17.4</pitest.version>
+        <coverage.min.line.ratio>0.60</coverage.min.line.ratio>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -296,5 +299,100 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>quality</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <configuration>
+                            <includes>
+                                <include>**/tech/amikos/chromadb/v2/*Test.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>tech/amikos/chromadb/v2/*</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>check</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule>
+                                            <element>PACKAGE</element>
+                                            <includes>
+                                                <include>tech.amikos.chromadb.v2*</include>
+                                            </includes>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${coverage.min.line.ratio}</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>mutation</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                        <version>${pitest.version}</version>
+                        <configuration>
+                            <targetClasses>
+                                <param>tech.amikos.chromadb.v2.*</param>
+                            </targetClasses>
+                            <targetTests>
+                                <param>tech.amikos.chromadb.v2.*Test</param>
+                            </targetTests>
+                            <outputFormats>
+                                <param>XML</param>
+                                <param>HTML</param>
+                            </outputFormats>
+                            <threads>2</threads>
+                            <timestampedReports>false</timestampedReports>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/tech/amikos/chromadb/v2/ChromaApiClient.java
+++ b/src/main/java/tech/amikos/chromadb/v2/ChromaApiClient.java
@@ -118,6 +118,15 @@ class ChromaApiClient implements AutoCloseable {
         return deserialize(response.body, responseType, response.statusCode);
     }
 
+    void put(String path, Object body) {
+        ensureOpen();
+        Request request = newRequest()
+                .url(buildUrl(path))
+                .put(jsonBody(body))
+                .build();
+        execute(request);
+    }
+
     void delete(String path) {
         ensureOpen();
         Request request = newRequest()

--- a/src/main/java/tech/amikos/chromadb/v2/ChromaDtos.java
+++ b/src/main/java/tech/amikos/chromadb/v2/ChromaDtos.java
@@ -1,0 +1,387 @@
+package tech.amikos.chromadb.v2;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Package-private JSON request/response DTOs for Gson serialization.
+ */
+final class ChromaDtos {
+
+    private ChromaDtos() {}
+
+    // --- Requests ---
+
+    static final class CreateTenantRequest {
+        final String name;
+
+        CreateTenantRequest(String name) {
+            this.name = name;
+        }
+    }
+
+    static final class CreateDatabaseRequest {
+        final String name;
+
+        CreateDatabaseRequest(String name) {
+            this.name = name;
+        }
+    }
+
+    static final class CreateCollectionRequest {
+        final String name;
+        final Map<String, Object> metadata;
+        @SerializedName("configuration")
+        final Map<String, Object> configuration;
+        @SerializedName("get_or_create")
+        final boolean getOrCreate;
+
+        CreateCollectionRequest(String name, Map<String, Object> metadata,
+                                Map<String, Object> configuration, boolean getOrCreate) {
+            this.name = name;
+            this.metadata = metadata;
+            this.configuration = configuration;
+            this.getOrCreate = getOrCreate;
+        }
+    }
+
+    static final class UpdateCollectionRequest {
+        @SerializedName("new_name")
+        final String newName;
+        @SerializedName("new_metadata")
+        final Map<String, Object> newMetadata;
+
+        UpdateCollectionRequest(String newName, Map<String, Object> newMetadata) {
+            this.newName = newName;
+            this.newMetadata = newMetadata;
+        }
+    }
+
+    static final class AddRequest {
+        final List<String> ids;
+        final List<List<Float>> embeddings;
+        final List<String> documents;
+        final List<Map<String, Object>> metadatas;
+        final List<String> uris;
+
+        AddRequest(List<String> ids, List<List<Float>> embeddings,
+                   List<String> documents, List<Map<String, Object>> metadatas,
+                   List<String> uris) {
+            this.ids = ids;
+            this.embeddings = embeddings;
+            this.documents = documents;
+            this.metadatas = metadatas;
+            this.uris = uris;
+        }
+    }
+
+    static final class QueryRequest {
+        @SerializedName("query_embeddings")
+        final List<List<Float>> queryEmbeddings;
+        @SerializedName("n_results")
+        final int nResults;
+        final Map<String, Object> where;
+        @SerializedName("where_document")
+        final Map<String, Object> whereDocument;
+        final List<String> include;
+
+        QueryRequest(List<List<Float>> queryEmbeddings, int nResults,
+                     Map<String, Object> where, Map<String, Object> whereDocument,
+                     List<String> include) {
+            this.queryEmbeddings = queryEmbeddings;
+            this.nResults = nResults;
+            this.where = where;
+            this.whereDocument = whereDocument;
+            this.include = include;
+        }
+    }
+
+    static final class GetRequest {
+        final List<String> ids;
+        final Map<String, Object> where;
+        @SerializedName("where_document")
+        final Map<String, Object> whereDocument;
+        final List<String> include;
+        final Integer limit;
+        final Integer offset;
+
+        GetRequest(List<String> ids, Map<String, Object> where,
+                   Map<String, Object> whereDocument, List<String> include,
+                   Integer limit, Integer offset) {
+            this.ids = ids;
+            this.where = where;
+            this.whereDocument = whereDocument;
+            this.include = include;
+            this.limit = limit;
+            this.offset = offset;
+        }
+    }
+
+    static final class UpdateRequest {
+        final List<String> ids;
+        final List<List<Float>> embeddings;
+        final List<String> documents;
+        final List<Map<String, Object>> metadatas;
+
+        UpdateRequest(List<String> ids, List<List<Float>> embeddings,
+                      List<String> documents, List<Map<String, Object>> metadatas) {
+            this.ids = ids;
+            this.embeddings = embeddings;
+            this.documents = documents;
+            this.metadatas = metadatas;
+        }
+    }
+
+    static final class UpsertRequest {
+        final List<String> ids;
+        final List<List<Float>> embeddings;
+        final List<String> documents;
+        final List<Map<String, Object>> metadatas;
+        final List<String> uris;
+
+        UpsertRequest(List<String> ids, List<List<Float>> embeddings,
+                      List<String> documents, List<Map<String, Object>> metadatas,
+                      List<String> uris) {
+            this.ids = ids;
+            this.embeddings = embeddings;
+            this.documents = documents;
+            this.metadatas = metadatas;
+            this.uris = uris;
+        }
+    }
+
+    static final class DeleteRequest {
+        final List<String> ids;
+        final Map<String, Object> where;
+        @SerializedName("where_document")
+        final Map<String, Object> whereDocument;
+
+        DeleteRequest(List<String> ids, Map<String, Object> where,
+                      Map<String, Object> whereDocument) {
+            this.ids = ids;
+            this.where = where;
+            this.whereDocument = whereDocument;
+        }
+    }
+
+    // --- Responses ---
+
+    static final class TenantResponse {
+        String name;
+    }
+
+    static final class DatabaseResponse {
+        String name;
+        String tenant;
+    }
+
+    static final class CollectionResponse {
+        String id;
+        String name;
+        Map<String, Object> metadata;
+        Integer dimension;
+        @SerializedName("configuration_json")
+        Map<String, Object> configurationJson;
+    }
+
+    static final class QueryResponse {
+        List<List<String>> ids;
+        List<List<String>> documents;
+        List<List<Map<String, Object>>> metadatas;
+        List<List<List<Float>>> embeddings;
+        List<List<Float>> distances;
+        List<List<String>> uris;
+    }
+
+    static final class GetResponse {
+        List<String> ids;
+        List<String> documents;
+        List<Map<String, Object>> metadatas;
+        List<List<Float>> embeddings;
+        List<String> uris;
+    }
+
+    // --- Helpers ---
+
+    static List<Float> toFloatList(float[] array) {
+        if (array == null) {
+            return null;
+        }
+        List<Float> list = new ArrayList<Float>(array.length);
+        for (float f : array) {
+            list.add(f);
+        }
+        return list;
+    }
+
+    static float[] toFloatArray(List<Float> list) {
+        if (list == null) {
+            return null;
+        }
+        float[] array = new float[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            Float value = list.get(i);
+            if (value == null) {
+                throw new ChromaDeserializationException(
+                        "Server returned an embedding vector with a null value at index " + i,
+                        200
+                );
+            }
+            array[i] = value;
+        }
+        return array;
+    }
+
+    static List<List<Float>> toFloatLists(List<float[]> arrays) {
+        if (arrays == null) {
+            return null;
+        }
+        List<List<Float>> result = new ArrayList<List<Float>>(arrays.size());
+        for (float[] array : arrays) {
+            result.add(toFloatList(array));
+        }
+        return result;
+    }
+
+    static List<float[]> toFloatArrays(List<List<Float>> lists) {
+        if (lists == null) {
+            return null;
+        }
+        List<float[]> result = new ArrayList<float[]>(lists.size());
+        for (List<Float> list : lists) {
+            result.add(toFloatArray(list));
+        }
+        return result;
+    }
+
+    static Map<String, Object> toConfigurationMap(CollectionConfiguration config) {
+        if (config == null) {
+            return null;
+        }
+        Map<String, Object> params = new LinkedHashMap<String, Object>();
+        if (config.getSpace() != null) {
+            params.put("hnsw:space", config.getSpace().getValue());
+        }
+        if (config.getHnswM() != null) {
+            params.put("hnsw:M", config.getHnswM());
+        }
+        if (config.getHnswConstructionEf() != null) {
+            params.put("hnsw:construction_ef", config.getHnswConstructionEf());
+        }
+        if (config.getHnswSearchEf() != null) {
+            params.put("hnsw:search_ef", config.getHnswSearchEf());
+        }
+        if (config.getHnswBatchSize() != null) {
+            params.put("hnsw:batch_size", config.getHnswBatchSize());
+        }
+        if (config.getHnswSyncThreshold() != null) {
+            params.put("hnsw:sync_threshold", config.getHnswSyncThreshold());
+        }
+        if (params.isEmpty()) {
+            return null;
+        }
+        return params;
+    }
+
+    static CollectionConfiguration parseConfiguration(Map<String, Object> configJson) {
+        if (configJson == null || configJson.isEmpty()) {
+            return null;
+        }
+        CollectionConfiguration.Builder builder = CollectionConfiguration.builder();
+        Object space = configJson.get("hnsw:space");
+        if (space != null) {
+            if (!(space instanceof String)) {
+                throw invalidConfiguration("hnsw:space must be a string");
+            }
+            try {
+                builder.space(DistanceFunction.fromValue((String) space));
+            } catch (IllegalArgumentException e) {
+                throw new ChromaDeserializationException(
+                        "Server returned unsupported hnsw:space value: " + space,
+                        200,
+                        e
+                );
+            }
+        }
+        Object m = configJson.get("hnsw:M");
+        if (m != null) {
+            if (!(m instanceof Number)) {
+                throw invalidConfiguration("hnsw:M must be numeric");
+            }
+            int value = ((Number) m).intValue();
+            try {
+                builder.hnswM(value);
+            } catch (IllegalArgumentException e) {
+                throw invalidConfiguration("hnsw:M must be > 0 but was " + value, e);
+            }
+        }
+        Object constructionEf = configJson.get("hnsw:construction_ef");
+        if (constructionEf != null) {
+            if (!(constructionEf instanceof Number)) {
+                throw invalidConfiguration("hnsw:construction_ef must be numeric");
+            }
+            int value = ((Number) constructionEf).intValue();
+            try {
+                builder.hnswConstructionEf(value);
+            } catch (IllegalArgumentException e) {
+                throw invalidConfiguration("hnsw:construction_ef must be > 0 but was " + value, e);
+            }
+        }
+        Object searchEf = configJson.get("hnsw:search_ef");
+        if (searchEf != null) {
+            if (!(searchEf instanceof Number)) {
+                throw invalidConfiguration("hnsw:search_ef must be numeric");
+            }
+            int value = ((Number) searchEf).intValue();
+            try {
+                builder.hnswSearchEf(value);
+            } catch (IllegalArgumentException e) {
+                throw invalidConfiguration("hnsw:search_ef must be > 0 but was " + value, e);
+            }
+        }
+        Object batchSize = configJson.get("hnsw:batch_size");
+        if (batchSize != null) {
+            if (!(batchSize instanceof Number)) {
+                throw invalidConfiguration("hnsw:batch_size must be numeric");
+            }
+            int value = ((Number) batchSize).intValue();
+            try {
+                builder.hnswBatchSize(value);
+            } catch (IllegalArgumentException e) {
+                throw invalidConfiguration("hnsw:batch_size must be > 0 but was " + value, e);
+            }
+        }
+        Object syncThreshold = configJson.get("hnsw:sync_threshold");
+        if (syncThreshold != null) {
+            if (!(syncThreshold instanceof Number)) {
+                throw invalidConfiguration("hnsw:sync_threshold must be numeric");
+            }
+            int value = ((Number) syncThreshold).intValue();
+            try {
+                builder.hnswSyncThreshold(value);
+            } catch (IllegalArgumentException e) {
+                throw invalidConfiguration("hnsw:sync_threshold must be > 0 but was " + value, e);
+            }
+        }
+        return builder.build();
+    }
+
+    private static ChromaDeserializationException invalidConfiguration(String message) {
+        return new ChromaDeserializationException(
+                "Server returned invalid collection configuration: " + message,
+                200
+        );
+    }
+
+    private static ChromaDeserializationException invalidConfiguration(String message, Throwable cause) {
+        return new ChromaDeserializationException(
+                "Server returned invalid collection configuration: " + message,
+                200,
+                cause
+        );
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java
+++ b/src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java
@@ -1,0 +1,604 @@
+package tech.amikos.chromadb.v2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Package-private {@link Collection} implementation backed by HTTP transport.
+ */
+final class ChromaHttpCollection implements Collection {
+
+    private final ChromaApiClient apiClient;
+    private final String id;
+    private final Tenant tenant;
+    private final Database database;
+
+    private String name;
+    private Map<String, Object> metadata;
+    private Integer dimension;
+    private CollectionConfiguration configuration;
+
+    private ChromaHttpCollection(ChromaApiClient apiClient, String id, String name,
+                                 Tenant tenant, Database database,
+                                 Map<String, Object> metadata, Integer dimension,
+                                 CollectionConfiguration configuration) {
+        this.apiClient = apiClient;
+        this.id = id;
+        this.name = name;
+        this.tenant = tenant;
+        this.database = database;
+        this.metadata = copyMetadata(metadata);
+        this.dimension = dimension;
+        this.configuration = configuration;
+    }
+
+    static ChromaHttpCollection from(ChromaDtos.CollectionResponse dto,
+                                     ChromaApiClient apiClient,
+                                     Tenant tenant, Database database) {
+        if (dto == null) {
+            throw new ChromaDeserializationException(
+                    "Server returned an empty collection payload",
+                    200
+            );
+        }
+        return new ChromaHttpCollection(
+                apiClient,
+                requireNonBlankField("collection.id", dto.id),
+                requireNonBlankField("collection.name", dto.name),
+                tenant,
+                database,
+                dto.metadata,
+                dto.dimension,
+                ChromaDtos.parseConfiguration(dto.configurationJson)
+        );
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Tenant getTenant() {
+        return tenant;
+    }
+
+    @Override
+    public Database getDatabase() {
+        return database;
+    }
+
+    @Override
+    public Map<String, Object> getMetadata() {
+        return metadata == null ? null : Collections.unmodifiableMap(metadata);
+    }
+
+    @Override
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public CollectionConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public int count() {
+        String path = ChromaApiPaths.collectionCount(tenant.getName(), database.getName(), id);
+        return apiClient.get(path, Integer.class);
+    }
+
+    @Override
+    public void modifyName(String newName) {
+        String normalizedName = requireNonBlankArgument("newName", newName);
+        String path = ChromaApiPaths.collection(tenant.getName(), database.getName(), id);
+        apiClient.put(path, new ChromaDtos.UpdateCollectionRequest(normalizedName, null));
+        this.name = normalizedName;
+    }
+
+    @Override
+    public void modifyMetadata(Map<String, Object> metadata) {
+        String path = ChromaApiPaths.collection(tenant.getName(), database.getName(), id);
+        apiClient.put(path, new ChromaDtos.UpdateCollectionRequest(null, metadata));
+        if (metadata == null) {
+            this.metadata = null;
+            return;
+        }
+        Map<String, Object> merged = new LinkedHashMap<String, Object>();
+        if (this.metadata != null) {
+            merged.putAll(this.metadata);
+        }
+        merged.putAll(copyMetadata(metadata));
+        this.metadata = merged;
+    }
+
+    @Override
+    public AddBuilder add() {
+        return new AddBuilderImpl();
+    }
+
+    @Override
+    public QueryBuilder query() {
+        return new QueryBuilderImpl();
+    }
+
+    @Override
+    public GetBuilder get() {
+        return new GetBuilderImpl();
+    }
+
+    @Override
+    public UpdateBuilder update() {
+        return new UpdateBuilderImpl();
+    }
+
+    @Override
+    public UpsertBuilder upsert() {
+        return new UpsertBuilderImpl();
+    }
+
+    @Override
+    public DeleteBuilder delete() {
+        return new DeleteBuilderImpl();
+    }
+
+    // --- Builder implementations ---
+
+    private final class AddBuilderImpl implements AddBuilder {
+        private List<String> ids;
+        private List<float[]> embeddings;
+        private List<String> documents;
+        private List<Map<String, Object>> metadatas;
+        private List<String> uris;
+
+        @Override
+        public AddBuilder ids(String... ids) {
+            this.ids = Arrays.asList(ids);
+            return this;
+        }
+
+        @Override
+        public AddBuilder ids(List<String> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        @Override
+        public AddBuilder embeddings(float[]... embeddings) {
+            this.embeddings = Arrays.asList(embeddings);
+            return this;
+        }
+
+        @Override
+        public AddBuilder embeddings(List<float[]> embeddings) {
+            this.embeddings = embeddings;
+            return this;
+        }
+
+        @Override
+        public AddBuilder documents(String... documents) {
+            this.documents = Arrays.asList(documents);
+            return this;
+        }
+
+        @Override
+        public AddBuilder documents(List<String> documents) {
+            this.documents = documents;
+            return this;
+        }
+
+        @Override
+        public AddBuilder metadatas(List<Map<String, Object>> metadatas) {
+            this.metadatas = metadatas;
+            return this;
+        }
+
+        @Override
+        public AddBuilder uris(String... uris) {
+            this.uris = Arrays.asList(uris);
+            return this;
+        }
+
+        @Override
+        public AddBuilder uris(List<String> uris) {
+            this.uris = uris;
+            return this;
+        }
+
+        @Override
+        public void execute() {
+            if (ids == null || ids.isEmpty()) {
+                throw new IllegalArgumentException("ids must not be empty");
+            }
+            String path = ChromaApiPaths.collectionAdd(tenant.getName(), database.getName(), id);
+            apiClient.post(path, new ChromaDtos.AddRequest(
+                    ids,
+                    ChromaDtos.toFloatLists(embeddings),
+                    documents,
+                    metadatas,
+                    uris
+            ));
+        }
+    }
+
+    private final class UpsertBuilderImpl implements UpsertBuilder {
+        private List<String> ids;
+        private List<float[]> embeddings;
+        private List<String> documents;
+        private List<Map<String, Object>> metadatas;
+        private List<String> uris;
+
+        @Override
+        public UpsertBuilder ids(String... ids) {
+            this.ids = Arrays.asList(ids);
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder ids(List<String> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder embeddings(float[]... embeddings) {
+            this.embeddings = Arrays.asList(embeddings);
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder embeddings(List<float[]> embeddings) {
+            this.embeddings = embeddings;
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder documents(String... documents) {
+            this.documents = Arrays.asList(documents);
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder documents(List<String> documents) {
+            this.documents = documents;
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder metadatas(List<Map<String, Object>> metadatas) {
+            this.metadatas = metadatas;
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder uris(String... uris) {
+            this.uris = Arrays.asList(uris);
+            return this;
+        }
+
+        @Override
+        public UpsertBuilder uris(List<String> uris) {
+            this.uris = uris;
+            return this;
+        }
+
+        @Override
+        public void execute() {
+            if (ids == null || ids.isEmpty()) {
+                throw new IllegalArgumentException("ids must not be empty");
+            }
+            String path = ChromaApiPaths.collectionUpsert(tenant.getName(), database.getName(), id);
+            apiClient.post(path, new ChromaDtos.UpsertRequest(
+                    ids,
+                    ChromaDtos.toFloatLists(embeddings),
+                    documents,
+                    metadatas,
+                    uris
+            ));
+        }
+    }
+
+    private final class QueryBuilderImpl implements QueryBuilder {
+        private List<float[]> queryEmbeddings;
+        private int nResults = 10;
+        private Where where;
+        private WhereDocument whereDocument;
+        private List<Include> include;
+
+        @Override
+        public QueryBuilder queryTexts(String... texts) {
+            throw new UnsupportedOperationException(
+                    "queryTexts requires an embedding function, which is not yet supported");
+        }
+
+        @Override
+        public QueryBuilder queryTexts(List<String> texts) {
+            throw new UnsupportedOperationException(
+                    "queryTexts requires an embedding function, which is not yet supported");
+        }
+
+        @Override
+        public QueryBuilder queryEmbeddings(float[]... embeddings) {
+            this.queryEmbeddings = Arrays.asList(embeddings);
+            return this;
+        }
+
+        @Override
+        public QueryBuilder queryEmbeddings(List<float[]> embeddings) {
+            this.queryEmbeddings = embeddings;
+            return this;
+        }
+
+        @Override
+        public QueryBuilder nResults(int nResults) {
+            if (nResults <= 0) {
+                throw new IllegalArgumentException("nResults must be > 0");
+            }
+            this.nResults = nResults;
+            return this;
+        }
+
+        @Override
+        public QueryBuilder where(Where where) {
+            this.where = where;
+            return this;
+        }
+
+        @Override
+        public QueryBuilder whereDocument(WhereDocument whereDocument) {
+            this.whereDocument = whereDocument;
+            return this;
+        }
+
+        @Override
+        public QueryBuilder include(Include... include) {
+            this.include = Arrays.asList(include);
+            return this;
+        }
+
+        @Override
+        public QueryResult execute() {
+            if (queryEmbeddings == null || queryEmbeddings.isEmpty()) {
+                throw new IllegalArgumentException("queryEmbeddings must be provided");
+            }
+            List<String> includeValues = null;
+            if (include != null) {
+                includeValues = new ArrayList<String>(include.size());
+                for (Include inc : include) {
+                    includeValues.add(inc.getValue());
+                }
+            }
+            String path = ChromaApiPaths.collectionQuery(tenant.getName(), database.getName(), id);
+            ChromaDtos.QueryResponse dto = apiClient.post(path, new ChromaDtos.QueryRequest(
+                    ChromaDtos.toFloatLists(queryEmbeddings),
+                    nResults,
+                    where != null ? where.toMap() : null,
+                    whereDocument != null ? whereDocument.toMap() : null,
+                    includeValues
+            ), ChromaDtos.QueryResponse.class);
+            return QueryResultImpl.from(dto);
+        }
+    }
+
+    private final class GetBuilderImpl implements GetBuilder {
+        private List<String> ids;
+        private Where where;
+        private WhereDocument whereDocument;
+        private List<Include> include;
+        private Integer limit;
+        private Integer offset;
+
+        @Override
+        public GetBuilder ids(String... ids) {
+            this.ids = Arrays.asList(ids);
+            return this;
+        }
+
+        @Override
+        public GetBuilder ids(List<String> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        @Override
+        public GetBuilder where(Where where) {
+            this.where = where;
+            return this;
+        }
+
+        @Override
+        public GetBuilder whereDocument(WhereDocument whereDocument) {
+            this.whereDocument = whereDocument;
+            return this;
+        }
+
+        @Override
+        public GetBuilder include(Include... include) {
+            this.include = Arrays.asList(include);
+            return this;
+        }
+
+        @Override
+        public GetBuilder limit(int limit) {
+            if (limit < 0) {
+                throw new IllegalArgumentException("limit must be >= 0");
+            }
+            this.limit = limit;
+            return this;
+        }
+
+        @Override
+        public GetBuilder offset(int offset) {
+            if (offset < 0) {
+                throw new IllegalArgumentException("offset must be >= 0");
+            }
+            this.offset = offset;
+            return this;
+        }
+
+        @Override
+        public GetResult execute() {
+            List<String> includeValues = null;
+            if (include != null) {
+                includeValues = new ArrayList<String>(include.size());
+                for (Include inc : include) {
+                    includeValues.add(inc.getValue());
+                }
+            }
+            String path = ChromaApiPaths.collectionGet(tenant.getName(), database.getName(), id);
+            ChromaDtos.GetResponse dto = apiClient.post(path, new ChromaDtos.GetRequest(
+                    ids,
+                    where != null ? where.toMap() : null,
+                    whereDocument != null ? whereDocument.toMap() : null,
+                    includeValues,
+                    limit,
+                    offset
+            ), ChromaDtos.GetResponse.class);
+            return GetResultImpl.from(dto);
+        }
+    }
+
+    private final class UpdateBuilderImpl implements UpdateBuilder {
+        private List<String> ids;
+        private List<float[]> embeddings;
+        private List<String> documents;
+        private List<Map<String, Object>> metadatas;
+
+        @Override
+        public UpdateBuilder ids(String... ids) {
+            this.ids = Arrays.asList(ids);
+            return this;
+        }
+
+        @Override
+        public UpdateBuilder ids(List<String> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        @Override
+        public UpdateBuilder embeddings(float[]... embeddings) {
+            this.embeddings = Arrays.asList(embeddings);
+            return this;
+        }
+
+        @Override
+        public UpdateBuilder embeddings(List<float[]> embeddings) {
+            this.embeddings = embeddings;
+            return this;
+        }
+
+        @Override
+        public UpdateBuilder documents(String... documents) {
+            this.documents = Arrays.asList(documents);
+            return this;
+        }
+
+        @Override
+        public UpdateBuilder documents(List<String> documents) {
+            this.documents = documents;
+            return this;
+        }
+
+        @Override
+        public UpdateBuilder metadatas(List<Map<String, Object>> metadatas) {
+            this.metadatas = metadatas;
+            return this;
+        }
+
+        @Override
+        public void execute() {
+            if (ids == null || ids.isEmpty()) {
+                throw new IllegalArgumentException("ids must not be empty");
+            }
+            String path = ChromaApiPaths.collectionUpdate(tenant.getName(), database.getName(), id);
+            apiClient.post(path, new ChromaDtos.UpdateRequest(
+                    ids,
+                    ChromaDtos.toFloatLists(embeddings),
+                    documents,
+                    metadatas
+            ));
+        }
+    }
+
+    private final class DeleteBuilderImpl implements DeleteBuilder {
+        private List<String> ids;
+        private Where where;
+        private WhereDocument whereDocument;
+
+        @Override
+        public DeleteBuilder ids(String... ids) {
+            this.ids = Arrays.asList(ids);
+            return this;
+        }
+
+        @Override
+        public DeleteBuilder ids(List<String> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        @Override
+        public DeleteBuilder where(Where where) {
+            this.where = where;
+            return this;
+        }
+
+        @Override
+        public DeleteBuilder whereDocument(WhereDocument whereDocument) {
+            this.whereDocument = whereDocument;
+            return this;
+        }
+
+        @Override
+        public void execute() {
+            boolean hasIds = ids != null && !ids.isEmpty();
+            if (!hasIds && where == null && whereDocument == null) {
+                throw new IllegalArgumentException(
+                        "delete requires at least one criterion: ids, where, or whereDocument"
+                );
+            }
+            String path = ChromaApiPaths.collectionDelete(tenant.getName(), database.getName(), id);
+            apiClient.post(path, new ChromaDtos.DeleteRequest(
+                    ids,
+                    where != null ? where.toMap() : null,
+                    whereDocument != null ? whereDocument.toMap() : null
+            ));
+        }
+    }
+
+    private static String requireNonBlankField(String fieldName, String value) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new ChromaDeserializationException(
+                    "Server returned collection with missing " + fieldName,
+                    200
+            );
+        }
+        return value.trim();
+    }
+
+    private static String requireNonBlankArgument(String fieldName, String value) {
+        if (value == null) {
+            throw new NullPointerException(fieldName);
+        }
+        String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static Map<String, Object> copyMetadata(Map<String, Object> metadata) {
+        return metadata == null ? null : new LinkedHashMap<String, Object>(metadata);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/v2/Collection.java
+++ b/src/main/java/tech/amikos/chromadb/v2/Collection.java
@@ -15,7 +15,7 @@ import java.util.Map;
  *
  * // Query
  * QueryResult result = collection.query()
- *     .queryTexts("search term")
+ *     .queryEmbeddings(new float[]{0.12f, 0.34f, 0.56f})
  *     .nResults(10)
  *     .where(Where.eq("type", "article"))
  *     .include(Include.DOCUMENTS, Include.DISTANCES)

--- a/src/main/java/tech/amikos/chromadb/v2/GetResultImpl.java
+++ b/src/main/java/tech/amikos/chromadb/v2/GetResultImpl.java
@@ -1,0 +1,97 @@
+package tech.amikos.chromadb.v2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class GetResultImpl implements GetResult {
+
+    private final List<String> ids;
+    private final List<String> documents;
+    private final List<Map<String, Object>> metadatas;
+    private final List<float[]> embeddings;
+    private final List<String> uris;
+
+    private GetResultImpl(List<String> ids, List<String> documents,
+                          List<Map<String, Object>> metadatas,
+                          List<float[]> embeddings, List<String> uris) {
+        this.ids = immutableList(ids);
+        this.documents = immutableList(documents);
+        this.metadatas = immutableMetadataList(metadatas);
+        this.embeddings = immutableEmbeddings(embeddings);
+        this.uris = immutableList(uris);
+    }
+
+    static GetResultImpl from(ChromaDtos.GetResponse dto) {
+        if (dto.ids == null) {
+            throw new ChromaDeserializationException(
+                    "Server returned get result without required ids field",
+                    200
+            );
+        }
+        return new GetResultImpl(
+                dto.ids,
+                dto.documents,
+                dto.metadatas,
+                ChromaDtos.toFloatArrays(dto.embeddings),
+                dto.uris
+        );
+    }
+
+    @Override
+    public List<String> getIds() {
+        return ids;
+    }
+
+    @Override
+    public List<String> getDocuments() {
+        return documents;
+    }
+
+    @Override
+    public List<Map<String, Object>> getMetadatas() {
+        return metadatas;
+    }
+
+    @Override
+    public List<float[]> getEmbeddings() {
+        return embeddings;
+    }
+
+    @Override
+    public List<String> getUris() {
+        return uris;
+    }
+
+    private static <T> List<T> immutableList(List<T> list) {
+        if (list == null) {
+            return null;
+        }
+        return Collections.unmodifiableList(new ArrayList<T>(list));
+    }
+
+    private static List<Map<String, Object>> immutableMetadataList(List<Map<String, Object>> metadatas) {
+        if (metadatas == null) {
+            return null;
+        }
+        List<Map<String, Object>> copy = new ArrayList<Map<String, Object>>(metadatas.size());
+        for (Map<String, Object> metadata : metadatas) {
+            copy.add(metadata == null ? null : Collections.unmodifiableMap(new LinkedHashMap<String, Object>(metadata)));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    private static List<float[]> immutableEmbeddings(List<float[]> embeddings) {
+        if (embeddings == null) {
+            return null;
+        }
+        List<float[]> copy = new ArrayList<float[]>(embeddings.size());
+        for (float[] embedding : embeddings) {
+            copy.add(embedding == null ? null : Arrays.copyOf(embedding, embedding.length));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/v2/QueryResultImpl.java
+++ b/src/main/java/tech/amikos/chromadb/v2/QueryResultImpl.java
@@ -1,0 +1,137 @@
+package tech.amikos.chromadb.v2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class QueryResultImpl implements QueryResult {
+
+    private final List<List<String>> ids;
+    private final List<List<String>> documents;
+    private final List<List<Map<String, Object>>> metadatas;
+    private final List<List<float[]>> embeddings;
+    private final List<List<Float>> distances;
+    private final List<List<String>> uris;
+
+    private QueryResultImpl(List<List<String>> ids, List<List<String>> documents,
+                            List<List<Map<String, Object>>> metadatas,
+                            List<List<float[]>> embeddings, List<List<Float>> distances,
+                            List<List<String>> uris) {
+        this.ids = immutableNestedList(ids);
+        this.documents = immutableNestedList(documents);
+        this.metadatas = immutableNestedMetadata(metadatas);
+        this.embeddings = immutableNestedEmbeddings(embeddings);
+        this.distances = immutableNestedList(distances);
+        this.uris = immutableNestedList(uris);
+    }
+
+    static QueryResultImpl from(ChromaDtos.QueryResponse dto) {
+        if (dto.ids == null) {
+            throw new ChromaDeserializationException(
+                    "Server returned query result without required ids field",
+                    200
+            );
+        }
+        List<List<float[]>> embeddings = null;
+        if (dto.embeddings != null) {
+            embeddings = new ArrayList<List<float[]>>(dto.embeddings.size());
+            for (List<List<Float>> inner : dto.embeddings) {
+                embeddings.add(ChromaDtos.toFloatArrays(inner));
+            }
+        }
+        return new QueryResultImpl(
+                dto.ids,
+                dto.documents,
+                dto.metadatas,
+                embeddings,
+                dto.distances,
+                dto.uris
+        );
+    }
+
+    @Override
+    public List<List<String>> getIds() {
+        return ids;
+    }
+
+    @Override
+    public List<List<String>> getDocuments() {
+        return documents;
+    }
+
+    @Override
+    public List<List<Map<String, Object>>> getMetadatas() {
+        return metadatas;
+    }
+
+    @Override
+    public List<List<float[]>> getEmbeddings() {
+        return embeddings;
+    }
+
+    @Override
+    public List<List<Float>> getDistances() {
+        return distances;
+    }
+
+    @Override
+    public List<List<String>> getUris() {
+        return uris;
+    }
+
+    private static <T> List<List<T>> immutableNestedList(List<List<T>> source) {
+        if (source == null) {
+            return null;
+        }
+        List<List<T>> outer = new ArrayList<List<T>>(source.size());
+        for (List<T> inner : source) {
+            if (inner == null) {
+                outer.add(null);
+            } else {
+                outer.add(Collections.unmodifiableList(new ArrayList<T>(inner)));
+            }
+        }
+        return Collections.unmodifiableList(outer);
+    }
+
+    private static List<List<Map<String, Object>>> immutableNestedMetadata(List<List<Map<String, Object>>> source) {
+        if (source == null) {
+            return null;
+        }
+        List<List<Map<String, Object>>> outer = new ArrayList<List<Map<String, Object>>>(source.size());
+        for (List<Map<String, Object>> inner : source) {
+            if (inner == null) {
+                outer.add(null);
+                continue;
+            }
+            List<Map<String, Object>> innerCopy = new ArrayList<Map<String, Object>>(inner.size());
+            for (Map<String, Object> metadata : inner) {
+                innerCopy.add(metadata == null ? null : Collections.unmodifiableMap(new LinkedHashMap<String, Object>(metadata)));
+            }
+            outer.add(Collections.unmodifiableList(innerCopy));
+        }
+        return Collections.unmodifiableList(outer);
+    }
+
+    private static List<List<float[]>> immutableNestedEmbeddings(List<List<float[]>> source) {
+        if (source == null) {
+            return null;
+        }
+        List<List<float[]>> outer = new ArrayList<List<float[]>>(source.size());
+        for (List<float[]> inner : source) {
+            if (inner == null) {
+                outer.add(null);
+                continue;
+            }
+            List<float[]> innerCopy = new ArrayList<float[]>(inner.size());
+            for (float[] embedding : inner) {
+                innerCopy.add(embedding == null ? null : Arrays.copyOf(embedding, embedding.length));
+            }
+            outer.add(Collections.unmodifiableList(innerCopy));
+        }
+        return Collections.unmodifiableList(outer);
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/v2/ChromaClientImplTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/ChromaClientImplTest.java
@@ -1,0 +1,639 @@
+package tech.amikos.chromadb.v2;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.*;
+
+public class ChromaClientImplTest {
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+    private Client client;
+
+    @After
+    public void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    private Client newClient() {
+        client = ChromaClient.builder()
+                .baseUrl("http://localhost:" + wireMock.port())
+                .build();
+        return client;
+    }
+
+    private Client newClient(String tenant, String database) {
+        client = ChromaClient.builder()
+                .baseUrl("http://localhost:" + wireMock.port())
+                .tenant(tenant)
+                .database(database)
+                .build();
+        return client;
+    }
+
+    // --- heartbeat ---
+
+    @Test
+    public void testHeartbeat() {
+        stubFor(get(urlEqualTo("/api/v2/heartbeat"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"nanosecond heartbeat\":12345}")));
+
+        Client c = newClient();
+        String result = c.heartbeat();
+        assertEquals("12345", result);
+    }
+
+    @Test
+    public void testHeartbeatMissingRequiredFieldThrows() {
+        stubFor(get(urlEqualTo("/api/v2/heartbeat"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"other\":1}")));
+
+        try {
+            newClient().heartbeat();
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("nanosecond heartbeat"));
+        }
+    }
+
+    // --- version ---
+
+    @Test
+    public void testVersion() {
+        stubFor(get(urlEqualTo("/api/v2/version"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("\"1.0.0\"")));
+
+        Client c = newClient();
+        assertEquals("1.0.0", c.version());
+    }
+
+    // --- reset ---
+
+    @Test
+    public void testReset() {
+        stubFor(post(urlEqualTo("/api/v2/reset"))
+                .willReturn(aResponse().withStatus(200)));
+
+        Client c = newClient();
+        c.reset();
+
+        verify(postRequestedFor(urlEqualTo("/api/v2/reset")));
+    }
+
+    // --- createTenant ---
+
+    @Test
+    public void testCreateTenant() {
+        stubFor(post(urlEqualTo("/api/v2/tenants"))
+                .withRequestBody(equalToJson("{\"name\":\"my_tenant\"}"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\":\"my_tenant\"}")));
+
+        Client c = newClient();
+        Tenant tenant = c.createTenant("my_tenant");
+        assertEquals(Tenant.of("my_tenant"), tenant);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateTenantRejectsNullName() {
+        newClient().createTenant(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateTenantRejectsBlankName() {
+        newClient().createTenant("   ");
+    }
+
+    @Test(expected = ChromaConflictException.class)
+    public void testCreateTenantConflict() {
+        stubFor(post(urlEqualTo("/api/v2/tenants"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"already exists\"}")));
+
+        newClient().createTenant("my_tenant");
+    }
+
+    // --- getTenant ---
+
+    @Test
+    public void testGetTenant() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/my_tenant"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\":\"my_tenant\"}")));
+
+        Client c = newClient();
+        Tenant tenant = c.getTenant("my_tenant");
+        assertEquals(Tenant.of("my_tenant"), tenant);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetTenantRejectsBlankName() {
+        newClient().getTenant("   ");
+    }
+
+    @Test(expected = ChromaNotFoundException.class)
+    public void testGetTenantNotFound() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/unknown"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"not found\"}")));
+
+        newClient().getTenant("unknown");
+    }
+
+    @Test
+    public void testGetTenantMissingNameThrows() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/my_tenant"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\":null}")));
+
+        try {
+            newClient().getTenant("my_tenant");
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("tenant.name"));
+        }
+    }
+
+    // --- createDatabase ---
+
+    @Test
+    public void testCreateDatabase() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/default_tenant/databases"))
+                .withRequestBody(equalToJson("{\"name\":\"my_db\"}"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\":\"my_db\",\"tenant\":\"default_tenant\"}")));
+
+        Client c = newClient();
+        Database db = c.createDatabase("my_db");
+        assertEquals(Database.of("my_db"), db);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateDatabaseRejectsNullName() {
+        newClient().createDatabase(null);
+    }
+
+    @Test(expected = ChromaConflictException.class)
+    public void testCreateDatabaseConflict() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/default_tenant/databases"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"already exists\"}")));
+
+        newClient().createDatabase("my_db");
+    }
+
+    // --- getDatabase ---
+
+    @Test
+    public void testGetDatabase() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/my_db"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\":\"my_db\",\"tenant\":\"default_tenant\"}")));
+
+        Client c = newClient();
+        Database db = c.getDatabase("my_db");
+        assertEquals(Database.of("my_db"), db);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetDatabaseRejectsBlankName() {
+        newClient().getDatabase("  ");
+    }
+
+    @Test(expected = ChromaNotFoundException.class)
+    public void testGetDatabaseNotFound() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/unknown"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"not found\"}")));
+
+        newClient().getDatabase("unknown");
+    }
+
+    @Test
+    public void testGetDatabaseBlankNameThrows() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/my_db"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\":\"   \",\"tenant\":\"default_tenant\"}")));
+
+        try {
+            newClient().getDatabase("my_db");
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("database.name"));
+        }
+    }
+
+    // --- listDatabases ---
+
+    @Test
+    public void testListDatabases() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"name\":\"db1\",\"tenant\":\"default_tenant\"},{\"name\":\"db2\",\"tenant\":\"default_tenant\"}]")));
+
+        Client c = newClient();
+        List<Database> dbs = c.listDatabases();
+        assertEquals(2, dbs.size());
+        assertEquals(Database.of("db1"), dbs.get(0));
+        assertEquals(Database.of("db2"), dbs.get(1));
+    }
+
+    @Test
+    public void testListDatabasesWithMissingNameThrows() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"name\":\"db1\",\"tenant\":\"default_tenant\"},{\"tenant\":\"default_tenant\"}]")));
+
+        try {
+            newClient().listDatabases();
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("database.name"));
+        }
+    }
+
+    // --- deleteDatabase ---
+
+    @Test
+    public void testDeleteDatabase() {
+        stubFor(delete(urlEqualTo("/api/v2/tenants/default_tenant/databases/my_db"))
+                .willReturn(aResponse().withStatus(200)));
+
+        Client c = newClient();
+        c.deleteDatabase("my_db");
+
+        verify(deleteRequestedFor(urlEqualTo("/api/v2/tenants/default_tenant/databases/my_db")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteDatabaseRejectsBlankName() {
+        newClient().deleteDatabase(" ");
+    }
+
+    // --- createCollection ---
+
+    @Test
+    public void testCreateCollection() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .withRequestBody(matchingJsonPath("$.name", equalTo("test_col")))
+                .withRequestBody(matchingJsonPath("$.get_or_create", equalTo("false")))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\"}")));
+
+        Client c = newClient();
+        Collection col = c.createCollection("test_col");
+        assertNotNull(col);
+        assertEquals("col-id-1", col.getId());
+        assertEquals("test_col", col.getName());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateCollectionRejectsNullName() {
+        newClient().createCollection(null);
+    }
+
+    @Test(expected = ChromaConflictException.class)
+    public void testCreateCollectionConflict() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .willReturn(aResponse()
+                        .withStatus(409)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"already exists\"}")));
+
+        newClient().createCollection("test_col");
+    }
+
+    @Test
+    public void testCreateCollectionWithOptions() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .withRequestBody(matchingJsonPath("$.name", equalTo("test_col")))
+                .withRequestBody(matchingJsonPath("$.metadata.key", equalTo("val")))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\",\"metadata\":{\"key\":\"val\"}}")));
+
+        Client c = newClient();
+        java.util.Map<String, Object> meta = new java.util.HashMap<String, Object>();
+        meta.put("key", "val");
+        Collection col = c.createCollection("test_col",
+                CreateCollectionOptions.withMetadata(meta));
+        assertNotNull(col);
+        assertEquals("val", col.getMetadata().get("key"));
+    }
+
+    @Test
+    public void testCreateCollectionWithConfigurationOptions() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .withRequestBody(matchingJsonPath("$.name", equalTo("cfg_col")))
+                .withRequestBody(matchingJsonPath("$.configuration['hnsw:space']", equalTo("cosine")))
+                .withRequestBody(matchingJsonPath("$.configuration['hnsw:M']", equalTo("16")))
+                .withRequestBody(matchingJsonPath("$.configuration['hnsw:construction_ef']", equalTo("200")))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-cfg-1\",\"name\":\"cfg_col\",\"configuration_json\":{\"hnsw:space\":\"cosine\",\"hnsw:M\":16,\"hnsw:construction_ef\":200}}")));
+
+        Client c = newClient();
+        CollectionConfiguration cfg = CollectionConfiguration.builder()
+                .space(DistanceFunction.COSINE)
+                .hnswM(16)
+                .hnswConstructionEf(200)
+                .build();
+        Collection col = c.createCollection(
+                "cfg_col",
+                CreateCollectionOptions.builder().configuration(cfg).build());
+
+        assertNotNull(col.getConfiguration());
+        assertEquals(DistanceFunction.COSINE, col.getConfiguration().getSpace());
+        assertEquals(Integer.valueOf(16), col.getConfiguration().getHnswM());
+        assertEquals(Integer.valueOf(200), col.getConfiguration().getHnswConstructionEf());
+    }
+
+    // --- getCollection ---
+
+    @Test
+    public void testGetCollection() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/test_col"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\"}")));
+
+        Client c = newClient();
+        Collection col = c.getCollection("test_col");
+        assertEquals("col-id-1", col.getId());
+        assertEquals("test_col", col.getName());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetCollectionRejectsBlankName() {
+        newClient().getCollection(" ");
+    }
+
+    @Test(expected = ChromaNotFoundException.class)
+    public void testGetCollectionNotFound() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/unknown"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"not found\"}")));
+
+        newClient().getCollection("unknown");
+    }
+
+    @Test
+    public void testGetCollectionMissingIdThrows() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/test_col"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\":\"test_col\"}")));
+
+        try {
+            newClient().getCollection("test_col");
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("collection.id"));
+        }
+    }
+
+    // --- getOrCreateCollection ---
+
+    @Test
+    public void testGetOrCreateCollection() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .withRequestBody(matchingJsonPath("$.name", equalTo("test_col")))
+                .withRequestBody(matchingJsonPath("$.get_or_create", equalTo("true")))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\"}")));
+
+        Client c = newClient();
+        Collection col = c.getOrCreateCollection("test_col");
+        assertNotNull(col);
+        assertEquals("col-id-1", col.getId());
+    }
+
+    // --- listCollections ---
+
+    @Test
+    public void testListCollections() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"id\":\"id1\",\"name\":\"col1\"},{\"id\":\"id2\",\"name\":\"col2\"}]")));
+
+        Client c = newClient();
+        List<Collection> cols = c.listCollections();
+        assertEquals(2, cols.size());
+        assertEquals("col1", cols.get(0).getName());
+        assertEquals("col2", cols.get(1).getName());
+    }
+
+    @Test
+    public void testListCollectionsWithLimitOffset() {
+        stubFor(get(urlPathEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .withQueryParam("limit", equalTo("10"))
+                .withQueryParam("offset", equalTo("5"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"id\":\"id1\",\"name\":\"col1\"}]")));
+
+        Client c = newClient();
+        List<Collection> cols = c.listCollections(10, 5);
+        assertEquals(1, cols.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testListCollectionsRejectsNegativeLimit() {
+        newClient().listCollections(-1, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testListCollectionsRejectsNegativeOffset() {
+        newClient().listCollections(1, -1);
+    }
+
+    @Test
+    public void testListCollectionsMissingNameThrows() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"id\":\"id1\"}]")));
+
+        try {
+            newClient().listCollections();
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("collection.name"));
+        }
+    }
+
+    @Test
+    public void testListCollectionsWithNullEntryThrows() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"id\":\"id1\",\"name\":\"col1\"},null]")));
+
+        try {
+            newClient().listCollections();
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("null entry at index 1"));
+        }
+    }
+
+    // --- deleteCollection ---
+
+    @Test
+    public void testDeleteCollection() {
+        stubFor(delete(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/test_col"))
+                .willReturn(aResponse().withStatus(200)));
+
+        Client c = newClient();
+        c.deleteCollection("test_col");
+
+        verify(deleteRequestedFor(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/test_col")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteCollectionRejectsBlankName() {
+        newClient().deleteCollection("  ");
+    }
+
+    @Test(expected = ChromaNotFoundException.class)
+    public void testDeleteCollectionNotFound() {
+        stubFor(delete(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/unknown"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"not found\"}")));
+
+        newClient().deleteCollection("unknown");
+    }
+
+    // --- countCollections ---
+
+    @Test
+    public void testCountCollections() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections_count"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("5")));
+
+        Client c = newClient();
+        assertEquals(5, c.countCollections());
+    }
+
+    // --- close ---
+
+    @Test
+    public void testClose() {
+        Client c = newClient();
+        c.close();
+        // Double close should be safe
+        c.close();
+    }
+
+    // --- custom tenant/database ---
+
+    @Test
+    public void testCustomTenantDatabase() {
+        stubFor(post(urlEqualTo("/api/v2/tenants/my_tenant/databases/my_db/collections"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\"}")));
+
+        Client c = newClient("my_tenant", "my_db");
+        Collection col = c.createCollection("test_col");
+        assertNotNull(col);
+        assertEquals(Tenant.of("my_tenant"), col.getTenant());
+        assertEquals(Database.of("my_db"), col.getDatabase());
+    }
+
+    // --- collection metadata parsing ---
+
+    @Test
+    public void testCollectionWithFullMetadata() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/test_col"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\",\"metadata\":{\"key\":\"val\"},\"dimension\":128}")));
+
+        Client c = newClient();
+        Collection col = c.getCollection("test_col");
+        assertEquals("val", col.getMetadata().get("key"));
+        assertEquals(Integer.valueOf(128), col.getDimension());
+    }
+
+    @Test
+    public void testGetCollectionInvalidConfigurationSpaceThrows() {
+        stubFor(get(urlEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections/test_col"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\",\"configuration_json\":{\"hnsw:space\":123}}")));
+
+        try {
+            newClient().getCollection("test_col");
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("hnsw:space"));
+        }
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/v2/ChromaDtosContractTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/ChromaDtosContractTest.java
@@ -1,0 +1,77 @@
+package tech.amikos.chromadb.v2;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ChromaDtosContractTest {
+
+    @Test
+    public void testToFloatArrayRejectsNullElementWithIndex() {
+        try {
+            ChromaDtos.toFloatArray(Arrays.asList(1.0f, null, 3.0f));
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertEquals(200, e.getStatusCode());
+            assertTrue(e.getMessage().contains("index 1"));
+        }
+    }
+
+    @Test
+    public void testConfigurationRoundTripAllFields() {
+        CollectionConfiguration original = CollectionConfiguration.builder()
+                .space(DistanceFunction.IP)
+                .hnswM(32)
+                .hnswConstructionEf(120)
+                .hnswSearchEf(55)
+                .hnswBatchSize(500)
+                .hnswSyncThreshold(250)
+                .build();
+
+        Map<String, Object> configMap = ChromaDtos.toConfigurationMap(original);
+        CollectionConfiguration parsed = ChromaDtos.parseConfiguration(configMap);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testParseConfigurationRejectsNonStringSpace() {
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("hnsw:space", Integer.valueOf(1));
+        try {
+            ChromaDtos.parseConfiguration(config);
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("hnsw:space must be a string"));
+        }
+    }
+
+    @Test
+    public void testParseConfigurationRejectsUnknownSpace() {
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("hnsw:space", "unknown");
+        try {
+            ChromaDtos.parseConfiguration(config);
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("unsupported hnsw:space value"));
+            assertNotNull(e.getCause());
+        }
+    }
+
+    @Test
+    public void testParseConfigurationRejectsNonPositiveNumericValues() {
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("hnsw:M", Integer.valueOf(0));
+        try {
+            ChromaDtos.parseConfiguration(config);
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("hnsw:M must be > 0"));
+        }
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/v2/ChromaHttpCollectionTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/ChromaHttpCollectionTest.java
@@ -1,0 +1,649 @@
+package tech.amikos.chromadb.v2;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.*;
+
+public class ChromaHttpCollectionTest {
+
+    private static final String COLLECTIONS_PATH = "/api/v2/tenants/default_tenant/databases/default_database/collections";
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+    private Client client;
+    private Collection collection;
+
+    private static Where where(Map<String, Object> map) {
+        final Map<String, Object> copy = new LinkedHashMap<String, Object>(map);
+        return new Where() {
+            @Override
+            public Map<String, Object> toMap() {
+                return copy;
+            }
+        };
+    }
+
+    private static WhereDocument whereDocument(Map<String, Object> map) {
+        final Map<String, Object> copy = new LinkedHashMap<String, Object>(map);
+        return new WhereDocument() {
+            @Override
+            public Map<String, Object> toMap() {
+                return copy;
+            }
+        };
+    }
+
+    @Before
+    public void setUp() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\"}")));
+
+        client = ChromaClient.builder()
+                .baseUrl("http://localhost:" + wireMock.port())
+                .build();
+        collection = client.getOrCreateCollection("test_col");
+    }
+
+    @After
+    public void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    // --- count ---
+
+    @Test
+    public void testCount() {
+        stubFor(get(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/count"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("42")));
+
+        assertEquals(42, collection.count());
+    }
+
+    // --- modifyName ---
+
+    @Test
+    public void testModifyName() {
+        stubFor(put(urlEqualTo(COLLECTIONS_PATH + "/col-id-1"))
+                .withRequestBody(matchingJsonPath("$.new_name", equalTo("renamed")))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.modifyName("renamed");
+        assertEquals("renamed", collection.getName());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testModifyNameRejectsNull() {
+        collection.modifyName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testModifyNameRejectsBlank() {
+        collection.modifyName("   ");
+    }
+
+    // --- modifyMetadata ---
+
+    @Test
+    public void testModifyMetadata() {
+        stubFor(put(urlEqualTo(COLLECTIONS_PATH + "/col-id-1"))
+                .withRequestBody(matchingJsonPath("$.new_metadata.key", equalTo("val")))
+                .willReturn(aResponse().withStatus(200)));
+
+        Map<String, Object> meta = new HashMap<String, Object>();
+        meta.put("key", "val");
+        collection.modifyMetadata(meta);
+        assertEquals("val", collection.getMetadata().get("key"));
+    }
+
+    @Test
+    public void testModifyMetadataMergesWithExistingMetadata() {
+        stubFor(get(urlEqualTo(COLLECTIONS_PATH + "/test_col"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\",\"metadata\":{\"existing\":\"old\"}}")));
+        stubFor(put(urlEqualTo(COLLECTIONS_PATH + "/col-id-1"))
+                .withRequestBody(matchingJsonPath("$.new_metadata.new_key", equalTo("new_val")))
+                .willReturn(aResponse().withStatus(200)));
+
+        Collection col = client.getCollection("test_col");
+        Map<String, Object> update = new HashMap<String, Object>();
+        update.put("new_key", "new_val");
+        col.modifyMetadata(update);
+
+        assertEquals("old", col.getMetadata().get("existing"));
+        assertEquals("new_val", col.getMetadata().get("new_key"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCollectionMetadataIsUnmodifiable() {
+        stubFor(get(urlEqualTo(COLLECTIONS_PATH + "/test_col"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"col-id-1\",\"name\":\"test_col\",\"metadata\":{\"existing\":\"old\"}}")));
+
+        Collection col = client.getCollection("test_col");
+        col.getMetadata().put("x", "y");
+    }
+
+    // --- add ---
+
+    @Test
+    public void testAdd() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/add"))
+                .withRequestBody(matchingJsonPath("$.ids", containing("id1")))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.add()
+                .ids("id1", "id2")
+                .embeddings(new float[]{1.0f, 2.0f}, new float[]{3.0f, 4.0f})
+                .documents("doc1", "doc2")
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/add")));
+    }
+
+    @Test
+    public void testAddWithListArgs() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/add"))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.add()
+                .ids(Arrays.asList("id1"))
+                .embeddings(Collections.singletonList(new float[]{1.0f}))
+                .documents(Collections.singletonList("doc1"))
+                .metadatas(Collections.singletonList(Collections.<String, Object>singletonMap("k", "v")))
+                .uris(Collections.singletonList("uri1"))
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/add")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddRequiresIds() {
+        collection.add().documents("doc1").execute();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddRejectsEmptyIds() {
+        collection.add().ids(Collections.<String>emptyList()).execute();
+    }
+
+    // --- upsert ---
+
+    @Test
+    public void testUpsert() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/upsert"))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.upsert()
+                .ids("id1")
+                .embeddings(new float[]{1.0f, 2.0f})
+                .documents("doc1")
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/upsert")));
+    }
+
+    @Test
+    public void testUpsertWithUris() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/upsert"))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.upsert()
+                .ids("id1")
+                .uris("uri1")
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/upsert")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUpsertRequiresIds() {
+        collection.upsert().documents("doc1").execute();
+    }
+
+    // --- update ---
+
+    @Test
+    public void testUpdate() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/update"))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.update()
+                .ids("id1")
+                .documents("updated doc")
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/update")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUpdateRequiresIds() {
+        collection.update().documents("doc1").execute();
+    }
+
+    // --- delete ---
+
+    @Test
+    public void testDelete() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/delete"))
+                .withRequestBody(matchingJsonPath("$.ids", containing("id1")))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.delete()
+                .ids("id1")
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/delete")));
+    }
+
+    @Test
+    public void testDeleteWithListIds() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/delete"))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.delete()
+                .ids(Arrays.asList("id1", "id2"))
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/delete")));
+    }
+
+    @Test
+    public void testDeleteWithNoArgs() {
+        try {
+            collection.delete().execute();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("at least one criterion"));
+        }
+    }
+
+    @Test
+    public void testDeleteWithWhereAndWhereDocument() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/delete"))
+                .withRequestBody(matchingJsonPath("$.where.topic", equalTo("news")))
+                .withRequestBody(matchingJsonPath("$.where_document.$contains", equalTo("ai")))
+                .willReturn(aResponse().withStatus(200)));
+
+        Map<String, Object> whereMap = new LinkedHashMap<String, Object>();
+        whereMap.put("topic", "news");
+        Map<String, Object> whereDocMap = new LinkedHashMap<String, Object>();
+        whereDocMap.put("$contains", "ai");
+
+        collection.delete()
+                .where(where(whereMap))
+                .whereDocument(whereDocument(whereDocMap))
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/delete")));
+    }
+
+    // --- query ---
+
+    @Test
+    public void testQuery() {
+        String responseBody = "{\"ids\":[[\"id1\",\"id2\"]],"
+                + "\"documents\":[[\"doc1\",\"doc2\"]],"
+                + "\"distances\":[[0.1,0.2]],"
+                + "\"metadatas\":[[{\"k\":\"v1\"},{\"k\":\"v2\"}]],"
+                + "\"embeddings\":[[[1.0,2.0],[3.0,4.0]]],"
+                + "\"uris\":[[\"uri1\",\"uri2\"]]}";
+
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/query"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBody)));
+
+        QueryResult result = collection.query()
+                .queryEmbeddings(new float[]{1.0f, 2.0f})
+                .nResults(5)
+                .include(Include.DOCUMENTS, Include.DISTANCES, Include.METADATAS, Include.EMBEDDINGS, Include.URIS)
+                .execute();
+
+        assertNotNull(result);
+        assertEquals(1, result.getIds().size());
+        assertEquals(2, result.getIds().get(0).size());
+        assertEquals("id1", result.getIds().get(0).get(0));
+        assertEquals("doc1", result.getDocuments().get(0).get(0));
+        assertEquals(Float.valueOf(0.1f), result.getDistances().get(0).get(0));
+        assertEquals("v1", result.getMetadatas().get(0).get(0).get("k"));
+        assertArrayEquals(new float[]{1.0f, 2.0f}, result.getEmbeddings().get(0).get(0), 0.001f);
+        assertEquals("uri1", result.getUris().get(0).get(0));
+    }
+
+    @Test
+    public void testQueryWithListEmbeddings() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/query"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[[\"id1\"]]}")));
+
+        QueryResult result = collection.query()
+                .queryEmbeddings(Collections.singletonList(new float[]{1.0f}))
+                .execute();
+
+        assertNotNull(result);
+        assertEquals(1, result.getIds().size());
+    }
+
+    @Test
+    public void testQueryWithWhereAndWhereDocument() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/query"))
+                .withRequestBody(matchingJsonPath("$.where.topic", equalTo("news")))
+                .withRequestBody(matchingJsonPath("$.where_document.$contains", equalTo("ai")))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[[\"id1\"]]}")));
+
+        Map<String, Object> whereMap = new LinkedHashMap<String, Object>();
+        whereMap.put("topic", "news");
+        Map<String, Object> whereDocMap = new LinkedHashMap<String, Object>();
+        whereDocMap.put("$contains", "ai");
+
+        QueryResult result = collection.query()
+                .queryEmbeddings(new float[]{1.0f})
+                .where(where(whereMap))
+                .whereDocument(whereDocument(whereDocMap))
+                .execute();
+
+        assertEquals(1, result.getIds().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testQueryRequiresEmbeddings() {
+        collection.query().nResults(10).execute();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testQueryRejectsNonPositiveNResults() {
+        collection.query().nResults(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testQueryTextsVarargsNotSupported() {
+        collection.query().queryTexts("text");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testQueryTextsListNotSupported() {
+        collection.query().queryTexts(Collections.singletonList("text"));
+    }
+
+    // --- get ---
+
+    @Test
+    public void testGet() {
+        String responseBody = "{\"ids\":[\"id1\",\"id2\"],"
+                + "\"documents\":[\"doc1\",\"doc2\"],"
+                + "\"metadatas\":[{\"k\":\"v1\"},{\"k\":\"v2\"}],"
+                + "\"embeddings\":[[1.0,2.0],[3.0,4.0]],"
+                + "\"uris\":[\"uri1\",\"uri2\"]}";
+
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBody)));
+
+        GetResult result = collection.get()
+                .ids("id1", "id2")
+                .include(Include.DOCUMENTS, Include.METADATAS, Include.EMBEDDINGS, Include.URIS)
+                .execute();
+
+        assertNotNull(result);
+        assertEquals(2, result.getIds().size());
+        assertEquals("id1", result.getIds().get(0));
+        assertEquals("doc1", result.getDocuments().get(0));
+        assertEquals("v1", result.getMetadatas().get(0).get("k"));
+        assertArrayEquals(new float[]{1.0f, 2.0f}, result.getEmbeddings().get(0), 0.001f);
+        assertEquals("uri1", result.getUris().get(0));
+    }
+
+    @Test
+    public void testGetWithLimitOffset() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .withRequestBody(matchingJsonPath("$.limit", equalTo("10")))
+                .withRequestBody(matchingJsonPath("$.offset", equalTo("5")))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[\"id1\"]}")));
+
+        GetResult result = collection.get()
+                .limit(10)
+                .offset(5)
+                .execute();
+
+        assertNotNull(result);
+        assertEquals(1, result.getIds().size());
+    }
+
+    @Test
+    public void testGetWithWhereAndWhereDocument() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .withRequestBody(matchingJsonPath("$.where.topic", equalTo("news")))
+                .withRequestBody(matchingJsonPath("$.where_document.$contains", equalTo("ai")))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[\"id1\"]}")));
+
+        Map<String, Object> whereMap = new LinkedHashMap<String, Object>();
+        whereMap.put("topic", "news");
+        Map<String, Object> whereDocMap = new LinkedHashMap<String, Object>();
+        whereDocMap.put("$contains", "ai");
+
+        GetResult result = collection.get()
+                .where(where(whereMap))
+                .whereDocument(whereDocument(whereDocMap))
+                .execute();
+
+        assertEquals(1, result.getIds().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetRejectsNegativeLimit() {
+        collection.get().limit(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetRejectsNegativeOffset() {
+        collection.get().offset(-1);
+    }
+
+    @Test
+    public void testGetAll() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[\"id1\",\"id2\"]}")));
+
+        GetResult result = collection.get().execute();
+
+        assertNotNull(result);
+        assertEquals(2, result.getIds().size());
+    }
+
+    @Test
+    public void testGetRejectsNullEmbeddingElement() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[\"id1\"],\"embeddings\":[[1.0,null]]}")));
+
+        try {
+            collection.get().ids("id1").execute();
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("null value at index 1"));
+        }
+    }
+
+    // --- collection accessors ---
+
+    @Test
+    public void testCollectionAccessors() {
+        assertEquals("col-id-1", collection.getId());
+        assertEquals("test_col", collection.getName());
+        assertEquals(Tenant.defaultTenant(), collection.getTenant());
+        assertEquals(Database.defaultDatabase(), collection.getDatabase());
+    }
+
+    // --- query result null fields ---
+
+    @Test
+    public void testQueryResultNullOptionalFields() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/query"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[[\"id1\"]]}")));
+
+        QueryResult result = collection.query()
+                .queryEmbeddings(new float[]{1.0f})
+                .execute();
+
+        assertNotNull(result.getIds());
+        assertNull(result.getDocuments());
+        assertNull(result.getMetadatas());
+        assertNull(result.getEmbeddings());
+        assertNull(result.getDistances());
+        assertNull(result.getUris());
+    }
+
+    @Test
+    public void testQueryResultRequiresIds() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/query"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"documents\":[[\"doc1\"]]}")));
+
+        try {
+            collection.query().queryEmbeddings(new float[]{1.0f}).execute();
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("required ids field"));
+        }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testQueryResultIdsOuterListIsUnmodifiable() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/query"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[[\"id1\"]]}")));
+
+        QueryResult result = collection.query()
+                .queryEmbeddings(new float[]{1.0f})
+                .execute();
+        result.getIds().add(Collections.singletonList("id2"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testQueryResultIdsInnerListIsUnmodifiable() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/query"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[[\"id1\"]]}")));
+
+        QueryResult result = collection.query()
+                .queryEmbeddings(new float[]{1.0f})
+                .execute();
+        result.getIds().get(0).add("id2");
+    }
+
+    // --- get result null fields ---
+
+    @Test
+    public void testGetResultNullOptionalFields() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[\"id1\"]}")));
+
+        GetResult result = collection.get().ids("id1").execute();
+
+        assertNotNull(result.getIds());
+        assertNull(result.getDocuments());
+        assertNull(result.getMetadatas());
+        assertNull(result.getEmbeddings());
+        assertNull(result.getUris());
+    }
+
+    @Test
+    public void testGetResultRequiresIds() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"documents\":[\"doc1\"]}")));
+
+        try {
+            collection.get().execute();
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("required ids field"));
+        }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetResultIdsListIsUnmodifiable() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/get"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"ids\":[\"id1\"]}")));
+
+        GetResult result = collection.get().ids("id1").execute();
+        result.getIds().add("id2");
+    }
+
+    // --- add with uris ---
+
+    @Test
+    public void testAddWithUris() {
+        stubFor(post(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/add"))
+                .willReturn(aResponse().withStatus(200)));
+
+        collection.add()
+                .ids("id1")
+                .uris("https://example.com/doc1")
+                .execute();
+
+        verify(postRequestedFor(urlEqualTo(COLLECTIONS_PATH + "/col-id-1/add")));
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/v2/CollectionConfigurationTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/CollectionConfigurationTest.java
@@ -200,4 +200,21 @@ public class CollectionConfigurationTest {
         assertNotEquals(a, c);
         assertTrue(a.toString().contains("hnswM=16"));
     }
+
+    @Test
+    public void testConfigurationMapRoundTrip() {
+        CollectionConfiguration original = CollectionConfiguration.builder()
+                .space(DistanceFunction.IP)
+                .hnswM(32)
+                .hnswConstructionEf(120)
+                .hnswSearchEf(55)
+                .hnswBatchSize(500)
+                .hnswSyncThreshold(250)
+                .build();
+
+        Map<String, Object> configMap = ChromaDtos.toConfigurationMap(original);
+        CollectionConfiguration parsed = ChromaDtos.parseConfiguration(configMap);
+
+        assertEquals(original, parsed);
+    }
 }


### PR DESCRIPTION
Closes #89, Closes #90

## Summary

- Implements `ChromaClientImpl` with full tenant, database, and collection CRUD operations via the v2 REST API
- Implements `ChromaHttpCollection` with fluent builders for all record operations: add, query, get, update, upsert, delete
- Adds `ChromaDtos` (request/response DTOs with Gson serialization, configuration parsing, and float array conversion)
- Adds immutable result types (`GetResultImpl`, `QueryResultImpl`) with deep defensive copies of all returned data
- Adds `void put()` overload to `ChromaApiClient` for fire-and-forget mutations
- Adds JaCoCo and PIT mutation testing under a `quality` Maven profile

### Key design decisions

- **Input validation at API boundaries**: `requireNonBlank` for user-provided names, `requireNonBlankField` for server response fields
- **Defensive immutability**: Result types deep-copy embeddings (`Arrays.copyOf`), wrap maps as unmodifiable, wrap lists as unmodifiable at every nesting level
- **Metadata merge semantics**: `modifyMetadata()` merges new entries with existing metadata (server call first, local update only on success)
- **Delete safety guard**: `DeleteBuilder.execute()` requires at least one of ids, where, or whereDocument to prevent accidental full-collection deletion
- **Builder validation**: All builders validate required fields and numeric constraints (nResults > 0, limit/offset >= 0)

### Files added/modified

**New source files:**
- `ChromaDtos.java` — 387 lines, package-private DTOs + conversion helpers
- `ChromaHttpCollection.java` — 604 lines, `Collection` implementation with 6 builder types
- `GetResultImpl.java` — 97 lines, immutable `GetResult` with deep copies
- `QueryResultImpl.java` — 137 lines, immutable `QueryResult` with nested deep copies

**Modified source files:**
- `ChromaClient.java` — adds `ChromaClientImpl` (248 lines), both builders now functional
- `ChromaApiClient.java` — adds `void put(String, Object)` overload
- `Collection.java` — fixes Javadoc (queryTexts → queryEmbeddings)
- `pom.xml` — adds JaCoCo/PIT quality profile

**New test files:**
- `ChromaClientImplTest.java` — 639 lines, WireMock tests for all client operations
- `ChromaHttpCollectionTest.java` — 649 lines, WireMock tests for collection + builders
- `ChromaDtosContractTest.java` — 77 lines, DTO serialization contracts

**Modified test files:**
- `ChromaApiClientTest.java` — adds void put tests
- `ChromaClientBuilderTest.java` — builder validation + cloud builder tests
- `CollectionConfigurationTest.java` — configuration map round-trip test

## Test plan

- [x] All existing tests pass (`mvn test`)
- [x] New WireMock-based tests cover happy paths, error codes, validation, immutability, and deserialization edge cases
- [x] Configuration round-trip test validates `toConfigurationMap` ↔ `parseConfiguration`
- [x] Filter serialization tests verify Where/WhereDocument maps reach the HTTP request body
- [x] 4 rounds of comprehensive PR review (code, error handling, tests, type design, comments) — all issues resolved
- [ ] Integration test with live ChromaDB (deferred to #91)