### PR TITLE
fix(v2): harden numeric and schema deserialization

### DIFF
--- a/src/main/java/tech/amikos/chromadb/v2/ChromaDtos.java
+++ b/src/main/java/tech/amikos/chromadb/v2/ChromaDtos.java
@@ -1366,10 +1366,12 @@ final class ChromaDtos {
         if (value == null) {
             return;
         }
-        if (!(value instanceof Number)) {
-            throw invalidConfiguration(key + " must be numeric");
+        int intValue;
+        try {
+            intValue = requireIntegerNumber(value, key);
+        } catch (IllegalArgumentException e) {
+            throw invalidConfiguration(e.getMessage(), e);
         }
-        int intValue = ((Number) value).intValue();
         try {
             consumer.accept(intValue);
         } catch (IllegalArgumentException e) {
@@ -1386,10 +1388,12 @@ final class ChromaDtos {
         if (value == null) {
             return;
         }
-        if (!(value instanceof Number)) {
-            throw invalidConfiguration(key + " must be numeric");
+        int intValue;
+        try {
+            intValue = requireIntegerNumber(value, key);
+        } catch (IllegalArgumentException e) {
+            throw invalidConfiguration(e.getMessage(), e);
         }
-        int intValue = ((Number) value).intValue();
         try {
             consumer.accept(intValue);
         } catch (IllegalArgumentException e) {
@@ -1424,10 +1428,24 @@ final class ChromaDtos {
         if (value == null) {
             return;
         }
+        consumer.accept(requireIntegerNumber(value, fieldName + "." + key));
+    }
+
+    private static int requireIntegerNumber(Object value, String fieldName) {
         if (!(value instanceof Number)) {
-            throw new IllegalArgumentException(fieldName + "." + key + " must be numeric");
+            throw new IllegalArgumentException(fieldName + " must be numeric");
         }
-        consumer.accept(((Number) value).intValue());
+        double doubleValue = ((Number) value).doubleValue();
+        if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+            throw new IllegalArgumentException(fieldName + " must be a finite integer");
+        }
+        if (doubleValue != Math.rint(doubleValue)) {
+            throw new IllegalArgumentException(fieldName + " must be an integer");
+        }
+        if (doubleValue > Integer.MAX_VALUE || doubleValue < Integer.MIN_VALUE) {
+            throw new IllegalArgumentException(fieldName + " must fit in 32-bit integer range");
+        }
+        return (int) doubleValue;
     }
 
     private static void parseDouble(Map<String, Object> map,

--- a/src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java
+++ b/src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java
@@ -70,7 +70,7 @@ final class ChromaHttpCollection implements Collection {
         Objects.requireNonNull(tenant, "tenant");
         Objects.requireNonNull(database, "database");
         CollectionConfiguration parsedConfiguration = ChromaDtos.parseConfiguration(dto.configurationJson);
-        Schema parsedTopLevelSchema = ChromaDtos.parseSchema(dto.schema);
+        Schema parsedTopLevelSchema = parseTopLevelSchema(dto.schema);
         Schema parsedConfigurationSchema = parsedConfiguration != null ? parsedConfiguration.getSchema() : null;
         Schema effectiveSchema = parsedTopLevelSchema != null ? parsedTopLevelSchema : parsedConfigurationSchema;
 
@@ -100,6 +100,23 @@ final class ChromaHttpCollection implements Collection {
                 explicitEmbeddingFunction,
                 effectiveSpec
         );
+    }
+
+    private static Schema parseTopLevelSchema(Map<String, Object> schemaJson) {
+        if (schemaJson == null || schemaJson.isEmpty()) {
+            return null;
+        }
+        try {
+            return ChromaDtos.parseSchema(schemaJson);
+        } catch (ChromaDeserializationException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new ChromaDeserializationException(
+                    "Server returned invalid collection schema: " + e.getMessage(),
+                    200,
+                    e
+            );
+        }
     }
 
     @Override

--- a/src/test/java/tech/amikos/chromadb/v2/ChromaDtosContractTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/ChromaDtosContractTest.java
@@ -240,6 +240,43 @@ public class ChromaDtosContractTest {
     }
 
     @Test
+    public void testParseConfigurationRejectsFractionalIntegerField() {
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("hnsw:search_ef", Double.valueOf(10.5));
+        try {
+            ChromaDtos.parseConfiguration(config);
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("hnsw:search_ef must be an integer"));
+        }
+    }
+
+    @Test
+    public void testParseSchemaRejectsFractionalIntegerField() {
+        Map<String, Object> schema = new LinkedHashMap<String, Object>();
+        Map<String, Object> keys = new LinkedHashMap<String, Object>();
+        Map<String, Object> embedding = new LinkedHashMap<String, Object>();
+        Map<String, Object> floatList = new LinkedHashMap<String, Object>();
+        Map<String, Object> vectorIndex = new LinkedHashMap<String, Object>();
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        Map<String, Object> hnsw = new LinkedHashMap<String, Object>();
+        hnsw.put("max_neighbors", Double.valueOf(16.7));
+        config.put("hnsw", hnsw);
+        vectorIndex.put("config", config);
+        floatList.put("vector_index", vectorIndex);
+        embedding.put("float_list", floatList);
+        keys.put(Schema.EMBEDDING_KEY, embedding);
+        schema.put("keys", keys);
+
+        try {
+            ChromaDtos.parseSchema(schema);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("max_neighbors must be an integer"));
+        }
+    }
+
+    @Test
     public void testCreateCollectionRequestIncludesTopLevelSchema() {
         Schema schema = Schema.builder()
                 .key(Schema.EMBEDDING_KEY, ValueTypes.builder()

--- a/src/test/java/tech/amikos/chromadb/v2/ChromaHttpCollectionTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/ChromaHttpCollectionTest.java
@@ -1850,6 +1850,39 @@ public class ChromaHttpCollectionTest {
         }
     }
 
+    @Test
+    public void testFromWrapsMalformedTopLevelSchemaAsDeserializationException() {
+        ChromaDtos.CollectionResponse dto = validCollectionDto();
+        Map<String, Object> schema = new LinkedHashMap<String, Object>();
+        Map<String, Object> keys = new LinkedHashMap<String, Object>();
+        Map<String, Object> embedding = new LinkedHashMap<String, Object>();
+        Map<String, Object> floatList = new LinkedHashMap<String, Object>();
+        Map<String, Object> vectorIndex = new LinkedHashMap<String, Object>();
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("hnsw", "invalid");
+        vectorIndex.put("config", config);
+        floatList.put("vector_index", vectorIndex);
+        embedding.put("float_list", floatList);
+        keys.put(Schema.EMBEDDING_KEY, embedding);
+        schema.put("keys", keys);
+        dto.schema = schema;
+
+        ChromaApiClient api = new ChromaApiClient(
+                "http://localhost:" + wireMock.port(), null, null, null, null, null);
+        try {
+            ChromaHttpCollection.from(dto, api, Tenant.defaultTenant(), Database.defaultDatabase(), null);
+            fail("Expected ChromaDeserializationException");
+        } catch (ChromaDeserializationException e) {
+            assertTrue(e.getMessage().contains("invalid collection schema"));
+            assertTrue(e.getMessage().contains("must be an object"));
+            assertEquals(200, e.getStatusCode());
+            assertNotNull(e.getCause());
+            assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+        } finally {
+            api.close();
+        }
+    }
+
     // --- add/upsert with IdGenerator ---
 
     @Test


### PR DESCRIPTION
## Summary
- reject fractional/non-finite/out-of-range numeric values for integer config fields instead of silently truncating
- wrap malformed top-level collection schema payloads as `ChromaDeserializationException` with HTTP 200 context
- add regression tests for both behaviors in DTO and collection parsing paths

## Testing
- mvn -q "-Dtest=tech.amikos.chromadb.v2.ChromaDtosContractTest,tech.amikos.chromadb.v2.ChromaHttpCollectionTest" test
- mvn -q "-Dtest=tech.amikos.chromadb.v2.*Test" test
