### PR TITLE
Phase 4: Embedding Ecosystem

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -31,7 +31,7 @@ Requirements for the current milestone. Each maps to roadmap phases.
 - [ ] **EMB-06**: User can use multimodal embedding functions (image+text) through a `MultimodalEmbeddingFunction` interface.
 - [ ] **EMB-07**: User can use at least 3 additional dense embedding providers (Gemini, Bedrock, Voyage prioritized) through the existing `EmbeddingFunction` contract.
 - [ ] **EMB-08**: User can rely on an `EmbeddingFunctionRegistry` to auto-wire embedding functions from server-side collection configuration.
-- [ ] **RERANK-01**: User can rerank query results using a `RerankingFunction` interface with at least one provider (Cohere or Jina).
+- [x] **RERANK-01**: User can rerank query results using a `RerankingFunction` interface with at least one provider (Cohere or Jina).
 
 ### Cloud Integration Testing
 
@@ -70,7 +70,7 @@ Deferred to future milestones.
 | EMB-06 | Phase 4 | Pending |
 | EMB-07 | Phase 4 | Pending |
 | EMB-08 | Phase 4 | Pending |
-| RERANK-01 | Phase 4 | Pending |
+| RERANK-01 | Phase 4 | Complete |
 | CLOUD-01 | Phase 5 | Complete |
 | CLOUD-02 | Phase 5 | Complete |
 | CLOUD-03 | Phase 5 | Complete |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -27,8 +27,8 @@ Requirements for the current milestone. Each maps to roadmap phases.
 
 ### Embedding Ecosystem
 
-- [ ] **EMB-05**: User can use sparse embedding functions (BM25, Chroma Cloud Splade) through a `SparseEmbeddingFunction` interface.
-- [ ] **EMB-06**: User can use multimodal embedding functions (image+text) through a `MultimodalEmbeddingFunction` interface.
+- [x] **EMB-05**: User can use sparse embedding functions (BM25, Chroma Cloud Splade) through a `SparseEmbeddingFunction` interface.
+- [x] **EMB-06**: User can use multimodal embedding functions (image+text) through a `MultimodalEmbeddingFunction` interface.
 - [ ] **EMB-07**: User can use at least 3 additional dense embedding providers (Gemini, Bedrock, Voyage prioritized) through the existing `EmbeddingFunction` contract.
 - [ ] **EMB-08**: User can rely on an `EmbeddingFunctionRegistry` to auto-wire embedding functions from server-side collection configuration.
 - [ ] **RERANK-01**: User can rerank query results using a `RerankingFunction` interface with at least one provider (Cohere or Jina).
@@ -66,8 +66,8 @@ Deferred to future milestones.
 | SEARCH-02 | Phase 3 | Complete |
 | SEARCH-03 | Phase 3 | Complete |
 | SEARCH-04 | Phase 3 | Complete |
-| EMB-05 | Phase 4 | Pending |
-| EMB-06 | Phase 4 | Pending |
+| EMB-05 | Phase 4 | Complete |
+| EMB-06 | Phase 4 | Complete |
 | EMB-07 | Phase 4 | Pending |
 | EMB-08 | Phase 4 | Pending |
 | RERANK-01 | Phase 4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -27,7 +27,7 @@ Requirements for the current milestone. Each maps to roadmap phases.
 
 ### Embedding Ecosystem
 
-- [ ] **EMB-05**: User can use sparse embedding functions (BM25, Chroma Cloud Splade) through a `SparseEmbeddingFunction` interface.
+- [x] **EMB-05**: User can use sparse embedding functions (BM25, Chroma Cloud Splade) through a `SparseEmbeddingFunction` interface.
 - [ ] **EMB-06**: User can use multimodal embedding functions (image+text) through a `MultimodalEmbeddingFunction` interface.
 - [x] **EMB-07**: User can use at least 3 additional dense embedding providers (Gemini, Bedrock, Voyage prioritized) through the existing `EmbeddingFunction` contract.
 - [ ] **EMB-08**: User can rely on an `EmbeddingFunctionRegistry` to auto-wire embedding functions from server-side collection configuration.
@@ -66,7 +66,7 @@ Deferred to future milestones.
 | SEARCH-02 | Phase 3 | Complete |
 | SEARCH-03 | Phase 3 | Complete |
 | SEARCH-04 | Phase 3 | Complete |
-| EMB-05 | Phase 4 | Pending |
+| EMB-05 | Phase 4 | Complete |
 | EMB-06 | Phase 4 | Pending |
 | EMB-07 | Phase 4 | Complete |
 | EMB-08 | Phase 4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -29,7 +29,7 @@ Requirements for the current milestone. Each maps to roadmap phases.
 
 - [ ] **EMB-05**: User can use sparse embedding functions (BM25, Chroma Cloud Splade) through a `SparseEmbeddingFunction` interface.
 - [ ] **EMB-06**: User can use multimodal embedding functions (image+text) through a `MultimodalEmbeddingFunction` interface.
-- [ ] **EMB-07**: User can use at least 3 additional dense embedding providers (Gemini, Bedrock, Voyage prioritized) through the existing `EmbeddingFunction` contract.
+- [x] **EMB-07**: User can use at least 3 additional dense embedding providers (Gemini, Bedrock, Voyage prioritized) through the existing `EmbeddingFunction` contract.
 - [ ] **EMB-08**: User can rely on an `EmbeddingFunctionRegistry` to auto-wire embedding functions from server-side collection configuration.
 - [ ] **RERANK-01**: User can rerank query results using a `RerankingFunction` interface with at least one provider (Cohere or Jina).
 
@@ -68,7 +68,7 @@ Deferred to future milestones.
 | SEARCH-04 | Phase 3 | Complete |
 | EMB-05 | Phase 4 | Pending |
 | EMB-06 | Phase 4 | Pending |
-| EMB-07 | Phase 4 | Pending |
+| EMB-07 | Phase 4 | Complete |
 | EMB-08 | Phase 4 | Pending |
 | RERANK-01 | Phase 4 | Pending |
 | CLOUD-01 | Phase 5 | Complete |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -22,6 +22,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [ ] **Phase 8: API DX Improvements** — Add Consumer lambda overloads for collection creation and Schema convenience factories (#143, #144).
 - [ ] **Phase 9: Logging Bridges** — Implement SLF4J and JUL bridges for ChromaLogger (#141, #142).
 - [ ] **Phase 10: Documentation Update** — Refresh docs site with DX improvements, logging bridges, and any API changes from Phases 8-9.
+- [ ] **Phase 11: Local/Embedded Client** — Add local/embedded client mode with JNI/JNA bindings or managed server lifecycle (#111).
 
 ## Phase Details
 
@@ -195,3 +196,20 @@ Plans:
 
 Plans:
 - [ ] TBD (run /gsd:plan-phase 10 to break down)
+
+### Phase 11: Local/Embedded Client
+
+**Goal:** Add a local/embedded client mode that runs Chroma without requiring a separate server, similar to Go client's `NewLocalClient`.
+**Depends on:** Nothing (independent — can be developed in parallel with other phases)
+**Requirements:** TBD
+**Issues:** #111
+**Success Criteria** (what must be TRUE):
+  1. `ChromaClient.local()` builder API exists with `persistDirectory` configuration.
+  2. At least one runtime mode works (JNI/JNA embedded or managed server lifecycle).
+  3. Persistence to disk supported with configurable path.
+  4. Unit and integration tests verify local client CRUD operations match server client behavior.
+  5. Graceful lifecycle management (startup, shutdown, cleanup).
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd:plan-phase 11 to break down)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -90,8 +90,8 @@ Plans:
 **Plans:** 5 plans
 
 Plans:
-- [ ] 04-01-PLAN.md — Sparse/Content interfaces, content value types, and bidirectional adapters
-- [ ] 04-02-PLAN.md — RerankingFunction interface with Cohere and Jina providers
+- [x] 04-01-PLAN.md — Sparse/Content interfaces, content value types, and bidirectional adapters
+- [x] 04-02-PLAN.md — RerankingFunction interface with Cohere and Jina providers
 - [ ] 04-03-PLAN.md — Dense providers: Gemini, Bedrock, Voyage with Maven deps
 - [ ] 04-04-PLAN.md — BM25 and ChromaCloudSplade sparse providers
 - [ ] 04-05-PLAN.md — EmbeddingFunctionRegistry with auto-wiring and ChromaHttpCollection integration

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -77,17 +77,24 @@ Plans:
 - [x] 03-03-PLAN.md — Create unit tests, integration tests, and update PublicInterfaceCompatibilityTest
 
 ### Phase 4: Embedding Ecosystem
-**Goal:** Expand the embedding ecosystem with sparse/multimodal interfaces, reranking functions, additional providers, and an auto-wiring registry.
+**Goal:** Expand the embedding ecosystem with sparse/content interfaces, reranking functions, additional dense providers, and an auto-wiring registry.
 **Depends on:** Nothing (independent of Phases 1-3)
 **Requirements:** [EMB-05, EMB-06, EMB-07, EMB-08, RERANK-01]
 **Issues:** #106, #107, #108, #109
 **Success Criteria** (what must be TRUE):
-  1. SparseEmbeddingFunction and MultimodalEmbeddingFunction interfaces exist with at least one provider each.
+  1. SparseEmbeddingFunction and ContentEmbeddingFunction interfaces exist with at least one provider each.
   2. RerankingFunction interface exists with at least one provider (Cohere or Jina).
   3. At least 3 new dense embedding providers implemented (prioritize Gemini, Bedrock, Voyage).
   4. EmbeddingFunctionRegistry supports registering and auto-wiring providers from server-side collection config.
   5. All providers have unit tests; integration tests where API keys are available.
-**Plans:** TBD
+**Plans:** 5 plans
+
+Plans:
+- [ ] 04-01-PLAN.md — Sparse/Content interfaces, content value types, and bidirectional adapters
+- [ ] 04-02-PLAN.md — RerankingFunction interface with Cohere and Jina providers
+- [ ] 04-03-PLAN.md — Dense providers: Gemini, Bedrock, Voyage with Maven deps
+- [ ] 04-04-PLAN.md — BM25 and ChromaCloudSplade sparse providers
+- [ ] 04-05-PLAN.md — EmbeddingFunctionRegistry with auto-wiring and ChromaHttpCollection integration
 
 ### Phase 5: Cloud Integration Testing
 **Goal:** Build deterministic cloud parity test suites that validate search, schema/index, and array metadata behavior against Chroma Cloud.
@@ -117,7 +124,7 @@ Phase 4 can execute in parallel with Phases 1-3 (independent).
 | 1. Result Ergonomics & WhereDocument | 2/3 | In Progress|  |
 | 2. Collection API Extensions | 2/2 | Complete | 2026-03-21 |
 | 3. Search API | 3/3 | Complete   | 2026-03-22 |
-| 4. Embedding Ecosystem | 0/TBD | Pending | — |
+| 4. Embedding Ecosystem | 0/5 | Planned | — |
 | 5. Cloud Integration Testing | 2/3 | In Progress|  |
 
 ### Phase 6: Documentation Site

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: milestone
 status: "Phase 06 shipped — PR #145"
-stopped_at: "Completed 06-04 Task 1; checkpoint:human-verify at Task 2"
-last_updated: "2026-04-01T10:06:39.889Z"
+stopped_at: Completed 04-02-PLAN.md (reranking interface and providers)
+last_updated: "2026-04-01T12:44:13.821Z"
 progress:
   total_phases: 14
   completed_phases: 12
   total_plans: 31
-  completed_plans: 31
+  completed_plans: 32
 ---
 
 # Project State
@@ -74,6 +74,7 @@ Plan: Not started
 | Phase 06-documentation-site P03 | 7 | 2 tasks | 11 files |
 | Phase 06-documentation-site P02 | 4 | 2 tasks | 12 files |
 | Phase 06-documentation-site P04 | 5 | 1 tasks | 9 files |
+| Phase 04-embedding-ecosystem P02 | 3min | 2 tasks | 11 files |
 
 ## Accumulated Context
 
@@ -155,6 +156,7 @@ Recent decisions affecting current work:
 - [Phase 06-documentation-site]: All guide pages use --8<-- named section snippet inclusions (no inline copy-pasted code blocks) per D-09
 - [Phase 06-documentation-site]: Examples stubs use 'coming soon' admonition with link to relevant guide page — Phase 7 fills content without touching nav config
 - [Phase 06-documentation-site]: mkdocs.yml Examples nav uses section syntax with java-examples/index.md as section index per navigation.indexes feature
+- [Phase 04-embedding-ecosystem]: WireMock tests use WithParam.baseAPI() injection instead of static field mutation -- defaults list captures DEFAULT_BASE_API at class-load time
 
 ### Roadmap Evolution
 
@@ -172,6 +174,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-03-24T15:42:20.817Z
-Stopped at: Completed 06-04 Task 1; checkpoint:human-verify at Task 2
+Last session: 2026-04-01T12:44:13.817Z
+Stopped at: Completed 04-02-PLAN.md (reranking interface and providers)
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: milestone
 status: "Phase 06 shipped — PR #145"
-stopped_at: "Completed 06-04 Task 1; checkpoint:human-verify at Task 2"
-last_updated: "2026-04-01T10:06:39.889Z"
+stopped_at: Completed 04-01-PLAN.md
+last_updated: "2026-04-01T12:43:00.327Z"
 progress:
   total_phases: 14
   completed_phases: 12
   total_plans: 31
-  completed_plans: 31
+  completed_plans: 32
 ---
 
 # Project State
@@ -74,6 +74,7 @@ Plan: Not started
 | Phase 06-documentation-site P03 | 7 | 2 tasks | 11 files |
 | Phase 06-documentation-site P02 | 4 | 2 tasks | 12 files |
 | Phase 06-documentation-site P04 | 5 | 1 tasks | 9 files |
+| Phase 04-embedding-ecosystem P01 | 3min | 2 tasks | 12 files |
 
 ## Accumulated Context
 
@@ -155,6 +156,8 @@ Recent decisions affecting current work:
 - [Phase 06-documentation-site]: All guide pages use --8<-- named section snippet inclusions (no inline copy-pasted code blocks) per D-09
 - [Phase 06-documentation-site]: Examples stubs use 'coming soon' admonition with link to relevant guide page — Phase 7 fills content without touching nav config
 - [Phase 06-documentation-site]: mkdocs.yml Examples nav uses section syntax with java-examples/index.md as section index per navigation.indexes feature
+- [Phase 04-embedding-ecosystem]: SparseEmbeddingFunction is separate interface (not extending EmbeddingFunction) — sparse and dense have incompatible return types
+- [Phase 04-embedding-ecosystem]: Content value types in embeddings.content subpackage per D-09; ContentEmbeddingFunction uses static factory fromTextOnly() for adapter creation
 
 ### Roadmap Evolution
 
@@ -172,6 +175,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-03-24T15:42:20.817Z
-Stopped at: Completed 06-04 Task 1; checkpoint:human-verify at Task 2
+Last session: 2026-04-01T12:43:00.324Z
+Stopped at: Completed 04-01-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: milestone
 status: "Phase 06 shipped — PR #145"
-stopped_at: Completed 04-03-PLAN.md
-last_updated: "2026-04-01T12:48:45.857Z"
+stopped_at: Completed 04-04-PLAN.md (BM25 & ChromaCloudSplade sparse providers)
+last_updated: "2026-04-01T12:59:42.481Z"
 progress:
   total_phases: 14
   completed_phases: 12
-  total_plans: 31
-  completed_plans: 32
+  total_plans: 36
+  completed_plans: 35
 ---
 
 # Project State
@@ -75,6 +75,7 @@ Plan: Not started
 | Phase 06-documentation-site P02 | 4 | 2 tasks | 12 files |
 | Phase 06-documentation-site P04 | 5 | 1 tasks | 9 files |
 | Phase 04-embedding-ecosystem P03 | 8min | 2 tasks | 9 files |
+| Phase 04-embedding-ecosystem PP04 | 6min | 2 tasks | 12 files |
 
 ## Accumulated Context
 
@@ -159,6 +160,8 @@ Recent decisions affecting current work:
 - [Phase 04-embedding-ecosystem]: Jackson version aligned to 2.17.2 via dependencyManagement to resolve nd4j/GenAI SDK conflict
 - [Phase 04-embedding-ecosystem]: Voyage WireMock tests use WithParam.baseAPI() constructor injection instead of static field reflection
 - [Phase 04-embedding-ecosystem]: Gemini/Bedrock use lazy double-checked locking for SDK client init to avoid load at construction time
+- [Phase 04-embedding-ecosystem]: englishStemmer class name is lowercase in snowball-stemmer 1.3.0.581.1
+- [Phase 04-embedding-ecosystem]: BM25StopWords contains 179 NLTK English stop words (not 174); ChromaCloudSplade uses Bearer token auth
 
 ### Roadmap Evolution
 
@@ -176,6 +179,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-04-01T12:48:45.854Z
-Stopped at: Completed 04-03-PLAN.md
+Last session: 2026-04-01T12:59:42.478Z
+Stopped at: Completed 04-04-PLAN.md (BM25 & ChromaCloudSplade sparse providers)
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: milestone
-status: "Phase 06 shipped — PR #145"
+status: "Phase 04 shipped — PR #146"
 stopped_at: Completed 04-04-PLAN.md (BM25 & ChromaCloudSplade sparse providers)
-last_updated: "2026-04-01T12:59:42.481Z"
+last_updated: "2026-04-02T07:03:38.118Z"
 progress:
   total_phases: 14
-  completed_phases: 12
+  completed_phases: 13
   total_plans: 36
-  completed_plans: 35
+  completed_plans: 36
 ---
 
 # Project State

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: milestone
 status: "Phase 06 shipped — PR #145"
-stopped_at: "Completed 06-04 Task 1; checkpoint:human-verify at Task 2"
-last_updated: "2026-04-01T10:06:39.889Z"
+stopped_at: Completed 04-03-PLAN.md
+last_updated: "2026-04-01T12:48:45.857Z"
 progress:
   total_phases: 14
   completed_phases: 12
   total_plans: 31
-  completed_plans: 31
+  completed_plans: 32
 ---
 
 # Project State
@@ -74,6 +74,7 @@ Plan: Not started
 | Phase 06-documentation-site P03 | 7 | 2 tasks | 11 files |
 | Phase 06-documentation-site P02 | 4 | 2 tasks | 12 files |
 | Phase 06-documentation-site P04 | 5 | 1 tasks | 9 files |
+| Phase 04-embedding-ecosystem P03 | 8min | 2 tasks | 9 files |
 
 ## Accumulated Context
 
@@ -155,6 +156,9 @@ Recent decisions affecting current work:
 - [Phase 06-documentation-site]: All guide pages use --8<-- named section snippet inclusions (no inline copy-pasted code blocks) per D-09
 - [Phase 06-documentation-site]: Examples stubs use 'coming soon' admonition with link to relevant guide page — Phase 7 fills content without touching nav config
 - [Phase 06-documentation-site]: mkdocs.yml Examples nav uses section syntax with java-examples/index.md as section index per navigation.indexes feature
+- [Phase 04-embedding-ecosystem]: Jackson version aligned to 2.17.2 via dependencyManagement to resolve nd4j/GenAI SDK conflict
+- [Phase 04-embedding-ecosystem]: Voyage WireMock tests use WithParam.baseAPI() constructor injection instead of static field reflection
+- [Phase 04-embedding-ecosystem]: Gemini/Bedrock use lazy double-checked locking for SDK client init to avoid load at construction time
 
 ### Roadmap Evolution
 
@@ -172,6 +176,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-03-24T15:42:20.817Z
-Stopped at: Completed 06-04 Task 1; checkpoint:human-verify at Task 2
+Last session: 2026-04-01T12:48:45.854Z
+Stopped at: Completed 04-03-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: milestone
 status: "Phase 06 shipped — PR #145"
-stopped_at: "Completed 06-04 Task 1; checkpoint:human-verify at Task 2"
-last_updated: "2026-04-01T10:06:39.889Z"
+stopped_at: Phase 04 context gathered
+last_updated: "2026-04-01T12:06:02.588Z"
 progress:
   total_phases: 14
   completed_phases: 12
@@ -172,6 +172,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-03-24T15:42:20.817Z
-Stopped at: Completed 06-04 Task 1; checkpoint:human-verify at Task 2
-Resume file: None
+Last session: 2026-04-01T12:06:02.585Z
+Stopped at: Phase 04 context gathered
+Resume file: .planning/phases/04-embedding-ecosystem/04-CONTEXT.md

--- a/.planning/phases/04-embedding-ecosystem/04-01-PLAN.md
+++ b/.planning/phases/04-embedding-ecosystem/04-01-PLAN.md
@@ -1,0 +1,364 @@
+---
+phase: 04-embedding-ecosystem
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java
+  - src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java
+  - src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
+  - src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
+  - src/main/java/tech/amikos/chromadb/embeddings/content/Content.java
+  - src/main/java/tech/amikos/chromadb/embeddings/content/Part.java
+  - src/main/java/tech/amikos/chromadb/embeddings/content/BinarySource.java
+  - src/main/java/tech/amikos/chromadb/embeddings/content/Modality.java
+  - src/main/java/tech/amikos/chromadb/embeddings/content/Intent.java
+  - src/test/java/tech/amikos/chromadb/embeddings/TestSparseEmbeddingFunction.java
+  - src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
+  - src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
+autonomous: true
+requirements: [EMB-05, EMB-06]
+
+must_haves:
+  truths:
+    - "SparseEmbeddingFunction interface exists with embedQuery and embedDocuments returning SparseVector types"
+    - "ContentEmbeddingFunction interface exists with embedContents(List<Content>) returning List<Embedding>"
+    - "Content.text('hello') creates a single-part text content"
+    - "Content.builder().part(Part.image(source)).intent(Intent.RETRIEVAL_DOCUMENT).build() creates multimodal content"
+    - "TextEmbeddingAdapter wraps EmbeddingFunction as ContentEmbeddingFunction"
+    - "ContentToTextAdapter wraps ContentEmbeddingFunction as EmbeddingFunction"
+    - "ContentEmbeddingFunction.fromTextOnly(ef) convenience factory works"
+  artifacts:
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java"
+      provides: "Sparse embedding interface"
+      exports: ["SparseEmbeddingFunction"]
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java"
+      provides: "Content embedding interface with adapter factory"
+      exports: ["ContentEmbeddingFunction"]
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/content/Content.java"
+      provides: "Content value type with static factory and builder"
+      exports: ["Content"]
+  key_links:
+    - from: "ContentEmbeddingFunction.java"
+      to: "content/Content.java"
+      via: "embedContents parameter type"
+      pattern: "embedContents.*List<Content>"
+    - from: "TextEmbeddingAdapter.java"
+      to: "EmbeddingFunction.java"
+      via: "wraps text-only EF as ContentEF"
+      pattern: "class TextEmbeddingAdapter implements ContentEmbeddingFunction"
+---
+
+<objective>
+Create the foundational interfaces and value types for sparse and content-based (multimodal) embedding functions, plus bidirectional adapters between text-only and content embedding functions.
+
+Purpose: All subsequent embedding providers (BM25, Splade, Gemini multimodal) depend on these interfaces. The content type hierarchy (Content, Part, BinarySource, Modality, Intent) provides the foundation for multimodal embedding support.
+
+Output: SparseEmbeddingFunction interface, ContentEmbeddingFunction interface with adapters, content value types, and comprehensive unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-embedding-ecosystem/04-CONTEXT.md
+@.planning/phases/04-embedding-ecosystem/04-RESEARCH.md
+
+@src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/embeddings/WithParam.java
+@src/main/java/tech/amikos/chromadb/v2/SparseVector.java
+@src/main/java/tech/amikos/chromadb/Embedding.java
+@src/main/java/tech/amikos/chromadb/EFException.java
+@src/main/java/tech/amikos/chromadb/v2/Include.java
+@src/main/java/tech/amikos/chromadb/v2/DistanceFunction.java
+
+<interfaces>
+<!-- Existing types the executor needs -->
+
+From EmbeddingFunction.java:
+```java
+public interface EmbeddingFunction {
+    Embedding embedQuery(String query) throws EFException;
+    List<Embedding> embedDocuments(List<String> documents) throws EFException;
+    List<Embedding> embedDocuments(String[] documents) throws EFException;
+    default List<Embedding> embedQueries(List<String> queries) throws EFException;
+    default List<Embedding> embedQueries(String[] queries) throws EFException;
+}
+```
+
+From SparseVector.java:
+```java
+public final class SparseVector {
+    public static SparseVector of(int[] indices, float[] values);
+    public int[] getIndices();
+    public float[] getValues();
+}
+```
+
+From Embedding.java:
+```java
+public class Embedding {
+    public Embedding(float[] embeddings);
+    public Embedding(List<? extends Number> embedding);
+    public List<Float> asList();
+    public float[] asArray();
+    public int getDimensions();
+    public static Embedding fromList(List<Float> embedding);
+    public static Embedding fromArray(float[] embedding);
+}
+```
+
+From DistanceFunction.java (enum pattern to replicate for Modality/Intent):
+```java
+public enum DistanceFunction {
+    L2("l2"), IP("ip"), COSINE("cosine");
+    private final String value;
+    DistanceFunction(String value) { this.value = value; }
+    public String getValue() { return value; }
+    public static DistanceFunction fromValue(String value) { ... }
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create SparseEmbeddingFunction, ContentEmbeddingFunction interfaces, content value types, and adapters</name>
+  <files>
+    src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java,
+    src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Content.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Part.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/BinarySource.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Modality.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Intent.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/v2/SparseVector.java,
+    src/main/java/tech/amikos/chromadb/Embedding.java,
+    src/main/java/tech/amikos/chromadb/EFException.java,
+    src/main/java/tech/amikos/chromadb/v2/DistanceFunction.java,
+    src/main/java/tech/amikos/chromadb/v2/Include.java
+  </read_first>
+  <behavior>
+    - SparseEmbeddingFunction.embedQuery("text") returns SparseVector
+    - SparseEmbeddingFunction.embedDocuments(List) returns List of SparseVector
+    - ContentEmbeddingFunction.embedContents(List of Content) returns List of Embedding
+    - ContentEmbeddingFunction.embedContent(single Content) returns single Embedding (default method delegates to embedContents)
+    - ContentEmbeddingFunction.fromTextOnly(ef) returns a TextEmbeddingAdapter instance
+    - TextEmbeddingAdapter extracts text parts from Content, delegates to wrapped EmbeddingFunction
+    - ContentToTextAdapter wraps ContentEmbeddingFunction, converts strings to Content.text(), delegates
+    - Content.text("hello") creates Content with single text Part
+    - Content.builder().part(Part.text("hi")).part(Part.image(src)).intent(Intent.RETRIEVAL_DOCUMENT).build() creates multi-part Content
+    - Part.text(str), Part.image(source), Part.audio(source) create typed parts
+    - BinarySource.fromUrl(url), .fromFile(path), .fromBase64(data), .fromBytes(data) create sources
+    - Modality enum: TEXT, IMAGE, AUDIO, VIDEO with getValue()/fromValue()
+    - Intent enum: RETRIEVAL_DOCUMENT, RETRIEVAL_QUERY, CLASSIFICATION, CLUSTERING with getValue()/fromValue()
+    - Content.getParts() returns unmodifiable list
+    - Content.getIntent() can be null (optional)
+    - Part.getModality() returns correct Modality for each factory method
+    - BinarySource constructed from bytes is retrievable via getBytes()
+  </behavior>
+  <action>
+    Create all interfaces and value types per D-01, D-05, D-06, D-07, D-08, D-09, D-10 from CONTEXT.md.
+
+    **SparseEmbeddingFunction.java** (per D-01 — separate interface, NOT extending EmbeddingFunction):
+    ```java
+    package tech.amikos.chromadb.embeddings;
+    import tech.amikos.chromadb.EFException;
+    import tech.amikos.chromadb.v2.SparseVector;
+    import java.util.List;
+
+    public interface SparseEmbeddingFunction {
+        SparseVector embedQuery(String query) throws EFException;
+        List<SparseVector> embedDocuments(List<String> documents) throws EFException;
+    }
+    ```
+
+    **ContentEmbeddingFunction.java** (per D-06, D-10):
+    ```java
+    package tech.amikos.chromadb.embeddings;
+    import tech.amikos.chromadb.EFException;
+    import tech.amikos.chromadb.Embedding;
+    import tech.amikos.chromadb.embeddings.content.Content;
+    import java.util.Collections;
+    import java.util.List;
+
+    public interface ContentEmbeddingFunction {
+        List<Embedding> embedContents(List<Content> contents) throws EFException;
+        default Embedding embedContent(Content content) throws EFException {
+            return embedContents(Collections.singletonList(content)).get(0);
+        }
+        static ContentEmbeddingFunction fromTextOnly(EmbeddingFunction ef) {
+            return new TextEmbeddingAdapter(ef);
+        }
+    }
+    ```
+
+    **TextEmbeddingAdapter.java** (per D-10): Public class. Constructor takes `EmbeddingFunction`. `embedContents` iterates contents, extracts first text Part from each Content via `content.getParts()` stream filtering by `Part.getModality() == Modality.TEXT`, gets `Part.getText()`, collects to `List<String>`, delegates to `wrapped.embedDocuments(texts)`. Throws `EFException("Content has no text part")` if any Content has no text Part.
+
+    **ContentToTextAdapter.java** (per D-10): Public class. Implements `EmbeddingFunction`. Constructor takes `ContentEmbeddingFunction`. `embedQuery(String)` wraps string as `Content.text(query)`, calls `wrapped.embedContent(content)`. `embedDocuments(List<String>)` maps each string to `Content.text(s)`, calls `wrapped.embedContents(contents)`. `embedDocuments(String[])` delegates to the List overload via `Arrays.asList()`.
+
+    **Content.java** (per D-07, in `embeddings.content` package):
+    - Final class. Fields: `List<Part> parts` (stored as `Collections.unmodifiableList`), `Intent intent` (nullable).
+    - `public static Content text(String text)` — creates Content with single `Part.text(text)`, null intent.
+    - `public static Builder builder()` — returns new Builder.
+    - `public List<Part> getParts()` — returns the unmodifiable list.
+    - `public Intent getIntent()` — returns intent or null.
+    - Inner `public static final class Builder`: `Builder part(Part part)`, `Builder intent(Intent intent)`, `Content build()`. build() throws IllegalArgumentException if parts is empty.
+    - equals/hashCode/toString.
+
+    **Part.java** (per D-07):
+    - Final class. Fields: `Modality modality`, `String text` (nullable), `BinarySource source` (nullable).
+    - `public static Part text(String text)` — modality=TEXT, text=text, source=null. Throws IllegalArgumentException if text is null.
+    - `public static Part image(BinarySource source)` — modality=IMAGE, text=null, source=source.
+    - `public static Part audio(BinarySource source)` — modality=AUDIO, text=null, source=source.
+    - `public static Part video(BinarySource source)` — modality=VIDEO, text=null, source=source.
+    - Getters: `getModality()`, `getText()`, `getSource()`.
+    - equals/hashCode/toString.
+
+    **BinarySource.java** (per D-07):
+    - Final class. Private constructor. Fields: `String url` (nullable), `String filePath` (nullable), `String base64Data` (nullable), `byte[] data` (nullable, defensive copy).
+    - Static factories: `fromUrl(String url)`, `fromFile(String path)`, `fromBase64(String base64)`, `fromBytes(byte[] data)`. Each sets only its field, others null.
+    - Getters: `getUrl()`, `getFilePath()`, `getBase64Data()`, `getBytes()` (defensive copy on bytes).
+    - equals/hashCode/toString.
+
+    **Modality.java** (per D-08 — same enum pattern as DistanceFunction):
+    ```java
+    public enum Modality {
+        TEXT("text"), IMAGE("image"), AUDIO("audio"), VIDEO("video");
+        private final String value;
+        Modality(String value) { this.value = value; }
+        public String getValue() { return value; }
+        public static Modality fromValue(String value) { /* iterate values(), match by value, throw IllegalArgumentException if no match */ }
+    }
+    ```
+
+    **Intent.java** (per D-08):
+    ```java
+    public enum Intent {
+        RETRIEVAL_DOCUMENT("retrieval_document"),
+        RETRIEVAL_QUERY("retrieval_query"),
+        CLASSIFICATION("classification"),
+        CLUSTERING("clustering");
+        // same pattern as Modality
+    }
+    ```
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn compile -pl . -q 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - SparseEmbeddingFunction.java contains `interface SparseEmbeddingFunction` and `SparseVector embedQuery(String query)`
+    - ContentEmbeddingFunction.java contains `interface ContentEmbeddingFunction` and `List<Embedding> embedContents(List<Content> contents)`
+    - ContentEmbeddingFunction.java contains `static ContentEmbeddingFunction fromTextOnly(EmbeddingFunction ef)`
+    - TextEmbeddingAdapter.java contains `class TextEmbeddingAdapter implements ContentEmbeddingFunction`
+    - ContentToTextAdapter.java contains `class ContentToTextAdapter implements EmbeddingFunction`
+    - Content.java in package `tech.amikos.chromadb.embeddings.content` contains `public static Content text(String text)` and `public static Builder builder()`
+    - Part.java contains `public static Part text(String text)` and `public static Part image(BinarySource source)`
+    - BinarySource.java contains `public static BinarySource fromUrl(String url)` and `public static BinarySource fromBytes(byte[] data)`
+    - Modality.java is an enum with TEXT, IMAGE, AUDIO, VIDEO and has `getValue()` and `fromValue(String)`
+    - Intent.java is an enum with RETRIEVAL_DOCUMENT, RETRIEVAL_QUERY, CLASSIFICATION, CLUSTERING and has `getValue()` and `fromValue(String)`
+    - `mvn compile` succeeds with no errors
+  </acceptance_criteria>
+  <done>All 9 source files compile. SparseEmbeddingFunction and ContentEmbeddingFunction interfaces defined. Content/Part/BinarySource value types with static factories and builder. Modality/Intent enums. TextEmbeddingAdapter and ContentToTextAdapter bidirectional adapters.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Unit tests for interfaces, content types, and adapters</name>
+  <files>
+    src/test/java/tech/amikos/chromadb/embeddings/TestSparseEmbeddingFunction.java,
+    src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java,
+    src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java,
+    src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Content.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Part.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/BinarySource.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Modality.java,
+    src/main/java/tech/amikos/chromadb/embeddings/content/Intent.java
+  </read_first>
+  <behavior>
+    - TestSparseEmbeddingFunction: anonymous impl returning known SparseVector; embedQuery returns expected indices/values; embedDocuments returns correct count
+    - TestContentEmbeddingFunction: anonymous impl returning known Embeddings; default embedContent delegates to embedContents; fromTextOnly wraps EF correctly
+    - TextEmbeddingAdapter: passes text parts to wrapped EF; throws EFException for content with no text part
+    - ContentToTextAdapter: wraps strings as Content.text; delegates to wrapped ContentEF; embedDocuments(String[]) delegates to List overload
+    - TestContentTypes: Content.text creates single-part; Content.builder with multiple parts; getParts is unmodifiable; builder with empty parts throws; Part.text/image/audio/video factories; Part null text throws; BinarySource.fromUrl/fromFile/fromBase64/fromBytes; BinarySource.getBytes defensive copy; Modality.fromValue round-trips; Intent.fromValue round-trips; Modality.fromValue invalid throws; Content equals/hashCode
+  </behavior>
+  <action>
+    Create three JUnit 4 test classes (matching project convention: JUnit 4, `@Test`, `assertEquals`, `assertNotNull`, `assertTrue`).
+
+    **TestSparseEmbeddingFunction.java**: Package `tech.amikos.chromadb.embeddings`.
+    - `testEmbedQueryReturnsVector`: Create anonymous `SparseEmbeddingFunction` returning `SparseVector.of(new int[]{1,2}, new float[]{0.5f, 0.8f})`. Call `embedQuery("test")`. Assert indices and values match.
+    - `testEmbedDocumentsReturnsList`: Same anonymous impl. Call `embedDocuments(Arrays.asList("a","b"))`. Assert size == 2.
+
+    **TestContentEmbeddingFunction.java**: Package `tech.amikos.chromadb.embeddings`.
+    - `testDefaultEmbedContentDelegatesToEmbedContents`: Create anonymous `ContentEmbeddingFunction` that records call count and returns `Embedding.fromArray(new float[]{1.0f})`. Call `embedContent(Content.text("hi"))`. Assert result dimensions == 1.
+    - `testFromTextOnlyWrapsEmbeddingFunction`: Create anonymous `EmbeddingFunction` returning known Embedding. Call `ContentEmbeddingFunction.fromTextOnly(ef)`. Call `embedContent(Content.text("hello"))`. Assert result matches.
+    - `testTextEmbeddingAdapterThrowsForNoTextPart`: Create `TextEmbeddingAdapter` wrapping dummy EF. Call `embedContents` with `Content.builder().part(Part.image(BinarySource.fromUrl("http://x"))).build()`. Expect `EFException`.
+    - `testContentToTextAdapterEmbedQuery`: Create anonymous `ContentEmbeddingFunction` that captures Content and returns Embedding. Wrap in `ContentToTextAdapter`. Call `embedQuery("test")`. Assert result returned.
+    - `testContentToTextAdapterEmbedDocumentsList`: Same setup. Call `embedDocuments(Arrays.asList("a","b"))`. Assert size == 2.
+    - `testContentToTextAdapterEmbedDocumentsArray`: Same setup. Call `embedDocuments(new String[]{"a","b"})`. Assert size == 2.
+
+    **TestContentTypes.java**: Package `tech.amikos.chromadb.embeddings.content`.
+    - `testContentTextFactory`: `Content.text("hello")` → getParts().size() == 1, getParts().get(0).getModality() == Modality.TEXT, getParts().get(0).getText().equals("hello"), getIntent() == null.
+    - `testContentBuilderMultipleParts`: `Content.builder().part(Part.text("hi")).part(Part.image(BinarySource.fromUrl("http://img"))).intent(Intent.RETRIEVAL_DOCUMENT).build()` → getParts().size() == 2, getIntent() == Intent.RETRIEVAL_DOCUMENT.
+    - `testContentPartsUnmodifiable`: `Content.text("a").getParts().add(...)` throws `UnsupportedOperationException`.
+    - `testContentBuilderEmptyPartsThrows`: `Content.builder().build()` throws `IllegalArgumentException`.
+    - `testPartTextFactory`: `Part.text("t")` → getModality() == Modality.TEXT, getText() == "t", getSource() == null.
+    - `testPartImageFactory`: `Part.image(BinarySource.fromUrl("u"))` → modality IMAGE, source not null, text null.
+    - `testPartTextNullThrows`: `Part.text(null)` throws `IllegalArgumentException`.
+    - `testBinarySourceFromUrl`: `BinarySource.fromUrl("http://x")` → getUrl() == "http://x", getFilePath() == null.
+    - `testBinarySourceFromBytes`: `BinarySource.fromBytes(new byte[]{1,2,3})` → getBytes() is [1,2,3]. Mutate returned array, call getBytes() again — still [1,2,3] (defensive copy).
+    - `testModalityFromValue`: `Modality.fromValue("text") == Modality.TEXT`, `Modality.fromValue("image") == Modality.IMAGE`.
+    - `testModalityFromValueInvalid`: `Modality.fromValue("bogus")` throws `IllegalArgumentException`.
+    - `testIntentFromValue`: `Intent.fromValue("retrieval_document") == Intent.RETRIEVAL_DOCUMENT`.
+    - `testContentEquality`: Two `Content.text("same")` are `.equals()` and have same hashCode.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn test -Dtest="TestSparseEmbeddingFunction,TestContentEmbeddingFunction,TestContentTypes" -pl . -q 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - TestSparseEmbeddingFunction.java exists with at least 2 @Test methods
+    - TestContentEmbeddingFunction.java exists with at least 5 @Test methods
+    - TestContentTypes.java exists with at least 10 @Test methods
+    - `mvn test -Dtest="TestSparseEmbeddingFunction,TestContentEmbeddingFunction,TestContentTypes"` exits 0 with all tests passing
+  </acceptance_criteria>
+  <done>All unit tests pass for SparseEmbeddingFunction interface, ContentEmbeddingFunction interface with adapters, and content value types (Content, Part, BinarySource, Modality, Intent).</done>
+</task>
+
+</tasks>
+
+<verification>
+- `mvn compile` succeeds (all new source files compile)
+- `mvn test -Dtest="TestSparseEmbeddingFunction,TestContentEmbeddingFunction,TestContentTypes"` — all tests pass
+- No existing tests broken: `mvn test` full suite passes
+</verification>
+
+<success_criteria>
+- SparseEmbeddingFunction interface exists as separate interface (not extending EmbeddingFunction) per D-01
+- ContentEmbeddingFunction interface exists with embedContents(List<Content>) per D-06
+- Content/Part/BinarySource follow static factory + builder pattern per D-07
+- Modality/Intent are Java enums with getValue()/fromValue() per D-08
+- All content types in tech.amikos.chromadb.embeddings.content package per D-09
+- Bidirectional adapters (TextEmbeddingAdapter, ContentToTextAdapter) exist per D-10
+- All unit tests pass
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-embedding-ecosystem/04-01-SUMMARY.md`
+</output>

--- a/.planning/phases/04-embedding-ecosystem/04-01-SUMMARY.md
+++ b/.planning/phases/04-embedding-ecosystem/04-01-SUMMARY.md
@@ -1,0 +1,123 @@
+---
+phase: 04-embedding-ecosystem
+plan: 01
+subsystem: embeddings
+tags: [sparse-vectors, multimodal, content-types, adapter-pattern, embedding-function]
+
+requires:
+  - phase: 03-embeddings-id-extensibility
+    provides: EmbeddingFunction interface, Embedding class, EFException, SparseVector value type
+provides:
+  - SparseEmbeddingFunction interface for sparse vector providers (BM25, SPLADE)
+  - ContentEmbeddingFunction interface for multimodal embedding providers (Gemini, CLIP)
+  - Content/Part/BinarySource value types for multimodal content representation
+  - Modality and Intent enums for content typing and embedding intent hints
+  - Bidirectional adapters (TextEmbeddingAdapter, ContentToTextAdapter)
+affects: [04-embedding-ecosystem, embedding-providers, gemini-multimodal, bm25-sparse]
+
+tech-stack:
+  added: []
+  patterns: [static-factory-plus-builder for Content, enum-with-fromValue for Modality/Intent, adapter pattern for EF bridging]
+
+key-files:
+  created:
+    - src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java
+    - src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java
+    - src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
+    - src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
+    - src/main/java/tech/amikos/chromadb/embeddings/content/Content.java
+    - src/main/java/tech/amikos/chromadb/embeddings/content/Part.java
+    - src/main/java/tech/amikos/chromadb/embeddings/content/BinarySource.java
+    - src/main/java/tech/amikos/chromadb/embeddings/content/Modality.java
+    - src/main/java/tech/amikos/chromadb/embeddings/content/Intent.java
+    - src/test/java/tech/amikos/chromadb/embeddings/TestSparseEmbeddingFunction.java
+    - src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
+    - src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
+  modified: []
+
+key-decisions:
+  - "SparseEmbeddingFunction is a separate interface (not extending EmbeddingFunction) per D-01 — sparse and dense have incompatible return types"
+  - "ContentEmbeddingFunction uses static factory fromTextOnly() rather than constructor for adapter creation — follows interface-first design"
+  - "Content value types placed in embeddings.content subpackage per D-09 — keeps embeddings package clean"
+
+patterns-established:
+  - "Static factory + builder for content types: Content.text() for simple, Content.builder() for complex"
+  - "Enum with getValue()/fromValue(String) pattern for Modality and Intent (same as DistanceFunction)"
+  - "Bidirectional adapter pattern: TextEmbeddingAdapter (text->content) and ContentToTextAdapter (content->text)"
+
+requirements-completed: [EMB-05, EMB-06]
+
+duration: 3min
+completed: 2026-04-01
+---
+
+# Phase 04 Plan 01: Embedding Foundation Interfaces Summary
+
+**Sparse and content-based embedding interfaces with multimodal Content type hierarchy and bidirectional adapters**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-04-01T12:39:27Z
+- **Completed:** 2026-04-01T12:42:05Z
+- **Tasks:** 2
+- **Files modified:** 12
+
+## Accomplishments
+- SparseEmbeddingFunction interface for sparse vector providers (BM25, SPLADE) returning SparseVector
+- ContentEmbeddingFunction interface with embedContents(List<Content>) for multimodal providers
+- Complete Content type hierarchy: Content, Part, BinarySource value types with static factories and builder
+- Modality (TEXT/IMAGE/AUDIO/VIDEO) and Intent (RETRIEVAL_DOCUMENT/RETRIEVAL_QUERY/CLASSIFICATION/CLUSTERING) enums
+- Bidirectional adapters enabling interop between text-only and content embedding functions
+- 23 unit tests covering all interfaces, value types, adapters, enums, and edge cases
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create interfaces, content types, and adapters** - `53e4fc2` (feat)
+2. **Task 2: Unit tests for interfaces, content types, and adapters** - `4d0aeac` (test)
+
+## Files Created/Modified
+- `src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java` - Sparse embedding interface returning SparseVector
+- `src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java` - Content embedding interface with fromTextOnly factory
+- `src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java` - Wraps EmbeddingFunction as ContentEmbeddingFunction
+- `src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java` - Wraps ContentEmbeddingFunction as EmbeddingFunction
+- `src/main/java/tech/amikos/chromadb/embeddings/content/Content.java` - Multimodal content with static factory and builder
+- `src/main/java/tech/amikos/chromadb/embeddings/content/Part.java` - Typed content parts (text, image, audio, video)
+- `src/main/java/tech/amikos/chromadb/embeddings/content/BinarySource.java` - Binary content source (URL, file, base64, bytes)
+- `src/main/java/tech/amikos/chromadb/embeddings/content/Modality.java` - TEXT/IMAGE/AUDIO/VIDEO enum
+- `src/main/java/tech/amikos/chromadb/embeddings/content/Intent.java` - RETRIEVAL_DOCUMENT/RETRIEVAL_QUERY/CLASSIFICATION/CLUSTERING enum
+- `src/test/java/tech/amikos/chromadb/embeddings/TestSparseEmbeddingFunction.java` - 2 tests
+- `src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java` - 6 tests
+- `src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java` - 15 tests
+
+## Decisions Made
+- SparseEmbeddingFunction is a separate interface (not extending EmbeddingFunction) per D-01 -- sparse and dense have incompatible return types
+- ContentEmbeddingFunction uses static factory fromTextOnly() rather than constructor for adapter creation -- follows interface-first design
+- Content value types placed in embeddings.content subpackage per D-09 -- keeps embeddings package clean
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Known Stubs
+
+None - all interfaces and types are fully implemented.
+
+## Next Phase Readiness
+- Foundation interfaces ready for concrete provider implementations (BM25, Gemini multimodal)
+- Content type hierarchy ready for embedding function registry integration
+- Adapters enable gradual migration from text-only to content-based embedding functions
+
+---
+*Phase: 04-embedding-ecosystem*
+*Completed: 2026-04-01*

--- a/.planning/phases/04-embedding-ecosystem/04-02-PLAN.md
+++ b/.planning/phases/04-embedding-ecosystem/04-02-PLAN.md
@@ -1,0 +1,287 @@
+---
+phase: 04-embedding-ecosystem
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java
+  - src/main/java/tech/amikos/chromadb/reranking/RerankResult.java
+  - src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java
+  - src/main/java/tech/amikos/chromadb/reranking/cohere/RerankRequest.java
+  - src/main/java/tech/amikos/chromadb/reranking/cohere/RerankResponse.java
+  - src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java
+  - src/main/java/tech/amikos/chromadb/reranking/jina/RerankRequest.java
+  - src/main/java/tech/amikos/chromadb/reranking/jina/RerankResponse.java
+  - src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java
+  - src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
+  - src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
+autonomous: true
+requirements: [RERANK-01]
+
+must_haves:
+  truths:
+    - "RerankingFunction interface exists with rerank(query, documents) returning List<RerankResult>"
+    - "RerankResult has index and score fields accessible via getters"
+    - "CohereRerankingFunction can be constructed with WithParam.apiKey and makes POST to Cohere v2 rerank endpoint"
+    - "JinaRerankingFunction can be constructed with WithParam.apiKey and makes POST to Jina v1 rerank endpoint"
+    - "Both providers sort results by descending relevance score"
+  artifacts:
+    - path: "src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java"
+      provides: "Reranking interface"
+      exports: ["RerankingFunction"]
+    - path: "src/main/java/tech/amikos/chromadb/reranking/RerankResult.java"
+      provides: "Rerank result value type"
+      exports: ["RerankResult"]
+    - path: "src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java"
+      provides: "Cohere Rerank v2 provider"
+      exports: ["CohereRerankingFunction"]
+    - path: "src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java"
+      provides: "Jina Reranker provider"
+      exports: ["JinaRerankingFunction"]
+  key_links:
+    - from: "CohereRerankingFunction.java"
+      to: "https://api.cohere.com/v2/rerank"
+      via: "OkHttp POST"
+      pattern: "api.cohere.com/v2/rerank"
+    - from: "JinaRerankingFunction.java"
+      to: "https://api.jina.ai/v1/rerank"
+      via: "OkHttp POST"
+      pattern: "api.jina.ai/v1/rerank"
+---
+
+<objective>
+Create the RerankingFunction interface and two provider implementations (Cohere Rerank v2, Jina Reranker) using OkHttp for HTTP calls.
+
+Purpose: Enables users to rerank query results by relevance using external reranking services. Both providers follow the established WithParam configuration pattern.
+
+Output: RerankingFunction interface, RerankResult value type, CohereRerankingFunction, JinaRerankingFunction, and unit tests with WireMock for HTTP assertions.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-embedding-ecosystem/04-CONTEXT.md
+@.planning/phases/04-embedding-ecosystem/04-RESEARCH.md
+
+@src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/embeddings/WithParam.java
+@src/main/java/tech/amikos/chromadb/embeddings/openai/OpenAIEmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/Constants.java
+@src/main/java/tech/amikos/chromadb/EFException.java
+
+<interfaces>
+<!-- Existing patterns to follow -->
+
+From WithParam.java:
+```java
+public abstract class WithParam {
+    public abstract void apply(Map<String, Object> params) throws EFException;
+    public static WithParam apiKey(String apiKey);
+    public static WithParam model(String model);
+    public static WithParam baseAPI(String baseAPI);
+}
+```
+
+From Constants.java:
+```java
+public static final String EF_PARAMS_BASE_API = "baseAPI";
+public static final String EF_PARAMS_MODEL = "modelName";
+public static final String EF_PARAMS_API_KEY = "apiKey";
+public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+```
+
+From OpenAIEmbeddingFunction (pattern to follow):
+```java
+public class OpenAIEmbeddingFunction implements EmbeddingFunction {
+    public static final String DEFAULT_MODEL_NAME = "...";
+    public static final String DEFAULT_BASE_API = "...";
+    public static final String OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+    private final OkHttpClient client = new OkHttpClient();
+    private final Gson gson = new Gson();
+    private final Map<String, Object> configParams = new HashMap<>();
+    private static final List<WithParam> defaults = Arrays.asList(...);
+    public OpenAIEmbeddingFunction(WithParam... params) throws EFException { ... }
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create RerankingFunction interface, RerankResult, and Cohere/Jina providers</name>
+  <files>
+    src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java,
+    src/main/java/tech/amikos/chromadb/reranking/RerankResult.java,
+    src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java,
+    src/main/java/tech/amikos/chromadb/reranking/cohere/RerankRequest.java,
+    src/main/java/tech/amikos/chromadb/reranking/cohere/RerankResponse.java,
+    src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java,
+    src/main/java/tech/amikos/chromadb/reranking/jina/RerankRequest.java,
+    src/main/java/tech/amikos/chromadb/reranking/jina/RerankResponse.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/embeddings/openai/OpenAIEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/WithParam.java,
+    src/main/java/tech/amikos/chromadb/Constants.java,
+    src/main/java/tech/amikos/chromadb/EFException.java,
+    src/main/java/tech/amikos/chromadb/embeddings/openai/CreateEmbeddingRequest.java,
+    src/main/java/tech/amikos/chromadb/embeddings/openai/CreateEmbeddingResponse.java
+  </read_first>
+  <behavior>
+    - RerankingFunction.rerank("query", docs) returns List of RerankResult
+    - RerankResult.of(0, 0.95) creates result with index=0, score=0.95
+    - RerankResult.getIndex() returns 0, RerankResult.getScore() returns 0.95
+    - CohereRerankingFunction(WithParam.apiKey("key")) constructs without error
+    - CohereRerankingFunction POSTs to https://api.cohere.com/v2/rerank with model, query, documents
+    - JinaRerankingFunction(WithParam.apiKey("key")) constructs without error
+    - JinaRerankingFunction POSTs to https://api.jina.ai/v1/rerank with model, query, documents
+  </behavior>
+  <action>
+    Create all reranking types per D-22, D-23 from CONTEXT.md.
+
+    **RerankingFunction.java** (per D-22):
+    ```java
+    package tech.amikos.chromadb.reranking;
+    import tech.amikos.chromadb.EFException;
+    import java.util.List;
+
+    public interface RerankingFunction {
+        List<RerankResult> rerank(String query, List<String> documents) throws EFException;
+    }
+    ```
+
+    **RerankResult.java** (per D-22):
+    ```java
+    package tech.amikos.chromadb.reranking;
+
+    public final class RerankResult {
+        private final int index;
+        private final double score;
+        private RerankResult(int index, double score) { this.index = index; this.score = score; }
+        public static RerankResult of(int index, double score) { return new RerankResult(index, score); }
+        public int getIndex() { return index; }
+        public double getScore() { return score; }
+        // equals, hashCode, toString
+    }
+    ```
+
+    **CohereRerankingFunction.java** (per D-23): Package `tech.amikos.chromadb.reranking.cohere`.
+    - Follow OpenAIEmbeddingFunction pattern exactly: `DEFAULT_BASE_API = "https://api.cohere.com/v2/rerank"`, `DEFAULT_MODEL_NAME = "rerank-v3.5"`, `COHERE_API_KEY_ENV = "COHERE_API_KEY"`.
+    - Fields: `OkHttpClient client`, `Gson gson`, `Map<String, Object> configParams`.
+    - Constructor: `CohereRerankingFunction(WithParam... params)` — apply defaults first, then user params (same pattern as OpenAI).
+    - `rerank(query, documents)`: Build `RerankRequest` with model, query, documents. POST as JSON. Parse `RerankResponse`. Map results to `List<RerankResult>` sorted by descending score.
+    - `RerankRequest`: Fields `String model`, `String query`, `List<String> documents`. Has `json()` method using Gson.
+    - `RerankResponse`: Fields `List<Result> results` where `Result` has `int index`, `double relevance_score`. Parsed by Gson.
+    - Auth header: `Authorization: Bearer {apiKey}`.
+    - Error handling: non-200 response throws `EFException("Cohere rerank failed: HTTP {code} - {body}")`. IOException wraps as EFException.
+
+    **JinaRerankingFunction.java** (per D-23): Package `tech.amikos.chromadb.reranking.jina`.
+    - Same pattern as Cohere. `DEFAULT_BASE_API = "https://api.jina.ai/v1/rerank"`, `DEFAULT_MODEL_NAME = "jina-reranker-v2-base-multilingual"`, `JINA_API_KEY_ENV = "JINA_API_KEY"`.
+    - Constructor: `JinaRerankingFunction(WithParam... params)`.
+    - `rerank(query, documents)`: Same flow. POST JSON, parse response, map to `List<RerankResult>`.
+    - `RerankRequest`: Fields `String model`, `String query`, `List<String> documents`.
+    - `RerankResponse`: Fields `List<Result> results` where `Result` has `int index`, `double relevance_score`.
+    - Auth header: `Authorization: Bearer {apiKey}`.
+    - Same error handling pattern.
+
+    Make `DEFAULT_BASE_API` fields `static` (not `static final`) and package-private to allow WireMock test injection (same pattern as DefaultEmbeddingFunction.modelDownloadUrl per prior phase decision).
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn compile -pl . -q 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - RerankingFunction.java contains `interface RerankingFunction` and `List<RerankResult> rerank(String query, List<String> documents)`
+    - RerankResult.java contains `public static RerankResult of(int index, double score)` and `public int getIndex()` and `public double getScore()`
+    - CohereRerankingFunction.java contains `api.cohere.com/v2/rerank` and `class CohereRerankingFunction implements RerankingFunction`
+    - JinaRerankingFunction.java contains `api.jina.ai/v1/rerank` and `class JinaRerankingFunction implements RerankingFunction`
+    - Both providers have `COHERE_API_KEY_ENV` / `JINA_API_KEY_ENV` constants
+    - `mvn compile` succeeds
+  </acceptance_criteria>
+  <done>RerankingFunction interface, RerankResult value type, CohereRerankingFunction (v2 endpoint), and JinaRerankingFunction all compile successfully.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Unit tests for RerankResult and WireMock tests for Cohere/Jina providers</name>
+  <files>
+    src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java,
+    src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java,
+    src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java,
+    src/main/java/tech/amikos/chromadb/reranking/RerankResult.java,
+    src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java,
+    src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java,
+    src/test/java/tech/amikos/chromadb/embeddings/TestDefaultEmbeddingFunction.java
+  </read_first>
+  <behavior>
+    - RerankResult.of(2, 0.85) → getIndex()==2, getScore()==0.85
+    - RerankResult equality: of(1, 0.5).equals(of(1, 0.5)) is true
+    - CohereRerankingFunction with WireMock: POST /v2/rerank returns valid JSON → rerank() returns List of RerankResult sorted by score desc
+    - CohereRerankingFunction with WireMock: POST returns 401 → throws EFException containing "401"
+    - JinaRerankingFunction with WireMock: POST /v1/rerank returns valid JSON → rerank() returns correct results
+    - JinaRerankingFunction with WireMock: POST returns 500 → throws EFException
+  </behavior>
+  <action>
+    Create JUnit 4 test classes. Use WireMock for HTTP testing (project already has WireMock as test dependency — check pom.xml for the version/import pattern used in existing tests).
+
+    **TestRerankResult.java**: Package `tech.amikos.chromadb.reranking`.
+    - `testOfAndGetters`: `RerankResult.of(2, 0.85)` → `getIndex() == 2`, `getScore() == 0.85` (with delta for double).
+    - `testEquality`: `RerankResult.of(1, 0.5).equals(RerankResult.of(1, 0.5))` is true, hashCodes match.
+    - `testInequality`: `RerankResult.of(1, 0.5).equals(RerankResult.of(2, 0.5))` is false.
+    - `testToString`: Contains "index=2" and "score=0.85".
+
+    **TestCohereRerankingFunction.java**: Package `tech.amikos.chromadb.reranking`.
+    - Use WireMock (`@Rule WireMockRule`). In `@Before`, set `CohereRerankingFunction.DEFAULT_BASE_API` to WireMock URL (package-private static field allows this).
+    - `testRerankSuccess`: Stub POST `/v2/rerank` returning `{"results":[{"index":1,"relevance_score":0.95},{"index":0,"relevance_score":0.72}]}`. Create `CohereRerankingFunction(WithParam.apiKey("test-key"))`. Call `rerank("query", Arrays.asList("doc0","doc1"))`. Assert result size == 2, first result index == 1 and score ~0.95 (highest first — sorted by desc score).
+    - `testRerankAuthFailure`: Stub POST `/v2/rerank` returning 401 with `{"message":"invalid api key"}`. Expect `EFException`. Assert message contains "401".
+    - `testRequestContainsAuthHeader`: Stub POST `/v2/rerank`. Call rerank. Verify WireMock received request with `Authorization: Bearer test-key` header.
+
+    **TestJinaRerankingFunction.java**: Package `tech.amikos.chromadb.reranking`.
+    - Same WireMock pattern. Set `JinaRerankingFunction.DEFAULT_BASE_API`.
+    - `testRerankSuccess`: Stub POST `/v1/rerank` returning `{"results":[{"index":0,"relevance_score":0.9},{"index":1,"relevance_score":0.3}]}`. Assert results mapped correctly.
+    - `testRerankServerError`: Stub POST returning 500. Expect `EFException`.
+    - `testRequestContainsModel`: Stub POST. Call rerank. Verify request body contains `"model":"jina-reranker-v2-base-multilingual"`.
+
+    After all WireMock tests, reset static fields in `@After` to original defaults.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn test -Dtest="TestRerankResult,TestCohereRerankingFunction,TestJinaRerankingFunction" -pl . -q 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - TestRerankResult.java exists with at least 3 @Test methods
+    - TestCohereRerankingFunction.java exists with at least 3 @Test methods using WireMock
+    - TestJinaRerankingFunction.java exists with at least 3 @Test methods using WireMock
+    - `mvn test -Dtest="TestRerankResult,TestCohereRerankingFunction,TestJinaRerankingFunction"` exits 0
+  </acceptance_criteria>
+  <done>All reranking unit tests pass: RerankResult value type, CohereRerankingFunction with WireMock HTTP assertions, JinaRerankingFunction with WireMock HTTP assertions.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `mvn compile` succeeds with all reranking source files
+- `mvn test -Dtest="TestRerankResult,TestCohereRerankingFunction,TestJinaRerankingFunction"` — all tests pass
+- No existing tests broken: `mvn test` full suite passes
+</verification>
+
+<success_criteria>
+- RerankingFunction interface with rerank(query, documents) per D-22
+- RerankResult with index + score via static factory per D-22
+- CohereRerankingFunction hitting Cohere v2/rerank endpoint per D-23
+- JinaRerankingFunction hitting Jina v1/rerank endpoint per D-23
+- Both use WithParam configuration pattern per D-15
+- WireMock tests verify HTTP calls, auth headers, and error handling
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-embedding-ecosystem/04-02-SUMMARY.md`
+</output>

--- a/.planning/phases/04-embedding-ecosystem/04-02-SUMMARY.md
+++ b/.planning/phases/04-embedding-ecosystem/04-02-SUMMARY.md
@@ -1,0 +1,129 @@
+---
+phase: 04-embedding-ecosystem
+plan: 02
+subsystem: embeddings
+tags: [reranking, cohere, jina, okhttp, wiremock]
+
+requires:
+  - phase: 03-embeddings-id-extensibility
+    provides: WithParam configuration pattern, EFException hierarchy
+provides:
+  - RerankingFunction interface for document reranking
+  - RerankResult immutable value type
+  - CohereRerankingFunction (Cohere v2/rerank endpoint)
+  - JinaRerankingFunction (Jina v1/rerank endpoint)
+affects: [04-embedding-ecosystem, embedding-registry]
+
+tech-stack:
+  added: []
+  patterns: [reranking-function-interface, wiremock-baseapi-injection-via-withparam]
+
+key-files:
+  created:
+    - src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java
+    - src/main/java/tech/amikos/chromadb/reranking/RerankResult.java
+    - src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java
+    - src/main/java/tech/amikos/chromadb/reranking/cohere/RerankRequest.java
+    - src/main/java/tech/amikos/chromadb/reranking/cohere/RerankResponse.java
+    - src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java
+    - src/main/java/tech/amikos/chromadb/reranking/jina/RerankRequest.java
+    - src/main/java/tech/amikos/chromadb/reranking/jina/RerankResponse.java
+    - src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java
+    - src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
+    - src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
+  modified: []
+
+key-decisions:
+  - "WireMock tests use WithParam.baseAPI() injection instead of static field mutation -- defaults list captures DEFAULT_BASE_API at class-load time so static field change has no effect on constructor"
+
+patterns-established:
+  - "RerankingFunction interface: rerank(query, documents) returns List<RerankResult> sorted by descending score"
+  - "Reranking providers follow same WithParam constructor pattern as embedding functions"
+  - "Package-private static DEFAULT_BASE_API for documentation; actual test injection via WithParam.baseAPI()"
+
+requirements-completed: [RERANK-01]
+
+duration: 3min
+completed: 2026-04-01
+---
+
+# Phase 04 Plan 02: Reranking Function Interface and Providers Summary
+
+**RerankingFunction interface with Cohere v2 and Jina v1 reranking providers using OkHttp and WithParam configuration**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-04-01T12:39:33Z
+- **Completed:** 2026-04-01T12:42:58Z
+- **Tasks:** 2
+- **Files modified:** 11
+
+## Accomplishments
+- RerankingFunction interface with rerank(query, documents) returning sorted List<RerankResult>
+- RerankResult immutable value type with index, score, equals/hashCode/toString
+- CohereRerankingFunction targeting Cohere v2/rerank with Bearer auth and configurable model
+- JinaRerankingFunction targeting Jina v1/rerank with Bearer auth and configurable model
+- WireMock tests verifying HTTP calls, auth headers, error handling, and request body content
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create RerankingFunction interface, RerankResult, and Cohere/Jina providers** - `303a717` (feat)
+2. **Task 2: Unit tests for RerankResult and WireMock tests for Cohere/Jina providers** - `b94c9ee` (test)
+
+## Files Created/Modified
+- `src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java` - Reranking interface with rerank(query, documents)
+- `src/main/java/tech/amikos/chromadb/reranking/RerankResult.java` - Immutable value type with index and score
+- `src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java` - Cohere v2/rerank provider
+- `src/main/java/tech/amikos/chromadb/reranking/cohere/RerankRequest.java` - Cohere request DTO
+- `src/main/java/tech/amikos/chromadb/reranking/cohere/RerankResponse.java` - Cohere response DTO
+- `src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java` - Jina v1/rerank provider
+- `src/main/java/tech/amikos/chromadb/reranking/jina/RerankRequest.java` - Jina request DTO
+- `src/main/java/tech/amikos/chromadb/reranking/jina/RerankResponse.java` - Jina response DTO
+- `src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java` - Value type unit tests (5 tests)
+- `src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java` - Cohere WireMock tests (3 tests)
+- `src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java` - Jina WireMock tests (3 tests)
+
+## Decisions Made
+- WireMock tests use WithParam.baseAPI() constructor injection rather than static field mutation because the defaults list captures DEFAULT_BASE_API value at class-load time, making static field changes ineffective for constructor-based URL resolution
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Changed WireMock URL injection from static field to WithParam.baseAPI()**
+- **Found during:** Task 2 (WireMock test creation)
+- **Issue:** Plan specified setting `DEFAULT_BASE_API` static field in `@Before`, but the `defaults` list captures the field value at class-load time via `WithParam.baseAPI(DEFAULT_BASE_API)`, so mutating the static field after class loading has no effect on constructor behavior
+- **Fix:** Tests pass `WithParam.baseAPI(wireMockUrl)` as constructor parameter instead of mutating static field
+- **Files modified:** TestCohereRerankingFunction.java, TestJinaRerankingFunction.java
+- **Verification:** All 11 tests pass
+- **Committed in:** b94c9ee (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** Necessary fix for test correctness. No scope creep.
+
+## Issues Encountered
+None
+
+## Known Stubs
+None - all interfaces are fully wired to HTTP endpoints.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- RerankingFunction interface ready for integration into Collection query workflows
+- Pattern established for adding additional reranking providers
+- WireMock test pattern ready for reuse with future providers
+
+## Self-Check: PASSED
+
+All 11 created files verified on disk. Both task commits (303a717, b94c9ee) verified in git log.
+
+---
+*Phase: 04-embedding-ecosystem*
+*Completed: 2026-04-01*

--- a/.planning/phases/04-embedding-ecosystem/04-03-PLAN.md
+++ b/.planning/phases/04-embedding-ecosystem/04-03-PLAN.md
@@ -1,0 +1,294 @@
+---
+phase: 04-embedding-ecosystem
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pom.xml
+  - src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
+  - src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
+  - src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
+  - src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingRequest.java
+  - src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java
+  - src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
+  - src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
+  - src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
+autonomous: true
+requirements: [EMB-07]
+
+must_haves:
+  truths:
+    - "GeminiEmbeddingFunction implements EmbeddingFunction and uses Google GenAI SDK"
+    - "BedrockEmbeddingFunction implements EmbeddingFunction and uses AWS SDK BedrockRuntime"
+    - "VoyageEmbeddingFunction implements EmbeddingFunction and uses OkHttp to call Voyage API"
+    - "All three providers accept WithParam configuration (apiKey, model, baseAPI)"
+    - "Google GenAI and AWS SDK are optional Maven dependencies"
+  artifacts:
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java"
+      provides: "Gemini embedding provider via Google GenAI SDK"
+      exports: ["GeminiEmbeddingFunction"]
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java"
+      provides: "AWS Bedrock embedding provider via AWS SDK"
+      exports: ["BedrockEmbeddingFunction"]
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java"
+      provides: "Voyage embedding provider via OkHttp"
+      exports: ["VoyageEmbeddingFunction"]
+  key_links:
+    - from: "GeminiEmbeddingFunction.java"
+      to: "com.google.genai SDK"
+      via: "SDK embedContent call"
+      pattern: "genaiClient.*embedContent"
+    - from: "BedrockEmbeddingFunction.java"
+      to: "software.amazon.awssdk.bedrockruntime"
+      via: "SDK invokeModel call"
+      pattern: "bedrockClient.*invokeModel"
+    - from: "VoyageEmbeddingFunction.java"
+      to: "https://api.voyageai.com/v1/embeddings"
+      via: "OkHttp POST"
+      pattern: "api.voyageai.com/v1/embeddings"
+---
+
+<objective>
+Add three new dense embedding providers (Gemini, Bedrock, Voyage) implementing the existing EmbeddingFunction interface, plus Maven dependency configuration for vendor SDKs.
+
+Purpose: Expands the dense embedding provider ecosystem from 5 to 8 providers, covering Google Cloud, AWS, and Voyage AI — matching Go client provider parity.
+
+Output: Three new provider classes, pom.xml dependency additions, and WireMock/unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-embedding-ecosystem/04-CONTEXT.md
+@.planning/phases/04-embedding-ecosystem/04-RESEARCH.md
+
+@src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/embeddings/WithParam.java
+@src/main/java/tech/amikos/chromadb/embeddings/openai/OpenAIEmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/Constants.java
+@pom.xml
+
+<interfaces>
+From EmbeddingFunction.java:
+```java
+public interface EmbeddingFunction {
+    Embedding embedQuery(String query) throws EFException;
+    List<Embedding> embedDocuments(List<String> documents) throws EFException;
+    List<Embedding> embedDocuments(String[] documents) throws EFException;
+    default List<Embedding> embedQueries(List<String> queries) throws EFException;
+}
+```
+
+From WithParam.java:
+```java
+public abstract class WithParam {
+    public static WithParam apiKey(String apiKey);
+    public static WithParam apiKeyFromEnv(String apiKeyEnvVarName);
+    public static WithParam model(String model);
+    public static WithParam baseAPI(String baseAPI);
+    public static WithParam defaultModel(String model);
+}
+```
+
+From Constants.java:
+```java
+public static final String EF_PARAMS_BASE_API = "baseAPI";
+public static final String EF_PARAMS_MODEL = "modelName";
+public static final String EF_PARAMS_API_KEY = "apiKey";
+public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+```
+
+OpenAI provider pattern (constructor):
+```java
+private static final List<WithParam> defaults = Arrays.asList(
+    WithParam.baseAPI(DEFAULT_BASE_API),
+    WithParam.defaultModel(DEFAULT_MODEL_NAME)
+);
+public OpenAIEmbeddingFunction(WithParam... params) throws EFException {
+    for (WithParam param : defaults) { param.apply(this.configParams); }
+    for (WithParam param : params) { param.apply(this.configParams); }
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add Maven dependencies and create Gemini, Bedrock, Voyage provider implementations</name>
+  <files>
+    pom.xml,
+    src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingRequest.java,
+    src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java
+  </files>
+  <read_first>
+    pom.xml,
+    src/main/java/tech/amikos/chromadb/embeddings/openai/OpenAIEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/openai/CreateEmbeddingRequest.java,
+    src/main/java/tech/amikos/chromadb/embeddings/openai/CreateEmbeddingResponse.java,
+    src/main/java/tech/amikos/chromadb/embeddings/WithParam.java,
+    src/main/java/tech/amikos/chromadb/Constants.java,
+    src/main/java/tech/amikos/chromadb/EFException.java,
+    src/main/java/tech/amikos/chromadb/Embedding.java
+  </read_first>
+  <action>
+    **pom.xml changes** (per D-13, D-14):
+    Add these dependencies in the `<dependencies>` section. Place them after existing embedding-related deps:
+
+    ```xml
+    <!-- Gemini embeddings (optional: user must add to their project) -->
+    <dependency>
+        <groupId>com.google.genai</groupId>
+        <artifactId>google-genai</artifactId>
+        <version>1.2.0</version>
+        <optional>true</optional>
+    </dependency>
+
+    <!-- AWS Bedrock embeddings (optional: user must add to their project) -->
+    <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bedrockruntime</artifactId>
+        <version>2.34.0</version>
+        <optional>true</optional>
+    </dependency>
+    ```
+
+    Voyage uses OkHttp (already a compile dependency) — no new dep needed.
+
+    **GeminiEmbeddingFunction.java** (per D-12, D-13, D-15):
+    Package `tech.amikos.chromadb.embeddings.gemini`. Implements `EmbeddingFunction`.
+    - Constants: `DEFAULT_MODEL_NAME = "text-embedding-004"`, `GEMINI_API_KEY_ENV = "GEMINI_API_KEY"`.
+    - Fields: `Map<String, Object> configParams`, lazily initialized `com.google.genai.Client` field.
+    - Constructor: `GeminiEmbeddingFunction(WithParam... params)` — apply `WithParam.defaultModel(DEFAULT_MODEL_NAME)` first, then user params. Extract API key from `configParams.get(Constants.EF_PARAMS_API_KEY)`.
+    - `embedQuery(String query)`: Call `embedDocuments(Collections.singletonList(query)).get(0)`.
+    - `embedDocuments(List<String> documents)`: For each document, call Google GenAI SDK: `client.models.embedContent(modelName, com.google.genai.types.Content.fromParts(com.google.genai.types.Part.fromText(doc)), null)`. Extract `response.embedding().values()` (List of Float), convert to `float[]`, wrap in `Embedding`. Note: SDK classes are `com.google.genai.types.Content` and `com.google.genai.types.Part` — fully qualify to avoid conflict with our content package.
+    - `embedDocuments(String[] documents)`: Delegate to `embedDocuments(Arrays.asList(documents))`.
+    - Error handling: Catch SDK exceptions, wrap in `EFException("Gemini embedding failed: " + e.getMessage(), e)`.
+    - Lazy client init: Build `com.google.genai.Client.builder().apiKey(apiKey).build()` on first call, not in constructor (avoids SDK load at construction if user just configures).
+
+    **BedrockEmbeddingFunction.java** (per D-12, D-13, D-15):
+    Package `tech.amikos.chromadb.embeddings.bedrock`. Implements `EmbeddingFunction`.
+    - Constants: `DEFAULT_MODEL_NAME = "amazon.titan-embed-text-v2:0"`, `AWS_REGION_ENV = "AWS_REGION"`, default region `"us-east-1"`.
+    - Fields: `Map<String, Object> configParams`, lazily initialized `BedrockRuntimeClient`.
+    - Constructor: `BedrockEmbeddingFunction(WithParam... params)` — apply `WithParam.defaultModel(DEFAULT_MODEL_NAME)` first, then user params. No API key needed — AWS SDK uses default credential chain (env vars, IAM role, etc.).
+    - Add a `public static WithParam region(String region)` as a custom WithParam subclass (inner class) that puts region into configParams under key `"awsRegion"`.
+    - `embedDocuments(List<String> documents)`: For each document, build JSON request body `{"inputText": doc, "dimensions": 1024, "normalize": true}` as `SdkBytes`. Call `bedrockClient.invokeModel(InvokeModelRequest.builder().modelId(modelName).body(requestBody).contentType("application/json").accept("application/json").build())`. Parse response JSON to extract `embedding` float array. Wrap in `Embedding`.
+    - Use Gson for JSON serialization/deserialization of request/response bodies (same as other providers).
+    - Lazy client init: Build `BedrockRuntimeClient.builder().region(Region.of(regionStr)).build()` on first call.
+
+    **VoyageEmbeddingFunction.java** (per D-12, D-15):
+    Package `tech.amikos.chromadb.embeddings.voyage`. Implements `EmbeddingFunction`.
+    - Constants: `DEFAULT_BASE_API = "https://api.voyageai.com/v1/embeddings"`, `DEFAULT_MODEL_NAME = "voyage-3.5"`, `VOYAGE_API_KEY_ENV = "VOYAGE_API_KEY"`.
+    - Fields: `OkHttpClient client`, `Gson gson`, `Map<String, Object> configParams`. Make `DEFAULT_BASE_API` a `static` (not final) package-private field for WireMock injection.
+    - Constructor: `VoyageEmbeddingFunction(WithParam... params)` — same pattern as OpenAI.
+    - `embedDocuments(List<String> documents)`: Build `CreateEmbeddingRequest` with `input` (documents), `model`, `input_type` = `"document"`. POST to baseAPI with `Authorization: Bearer {apiKey}`. Parse `CreateEmbeddingResponse`. Map `data[].embedding` arrays to `List<Embedding>`.
+    - `embedQuery(String query)`: Same but with `input_type` = `"query"` and single input.
+    - `embedDocuments(String[])`: Delegate to List overload.
+
+    **CreateEmbeddingRequest.java** (Voyage): Fields `List<String> input`, `String model`, `String input_type`. Method `String json()` using Gson.
+
+    **CreateEmbeddingResponse.java** (Voyage): Fields `List<DataItem> data` where `DataItem` has `List<Float> embedding` and `int index`. Method `List<Embedding> toEmbeddings()`.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn compile -pl . -q 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - pom.xml contains `<artifactId>google-genai</artifactId>` with `<optional>true</optional>`
+    - pom.xml contains `<artifactId>bedrockruntime</artifactId>` with `<optional>true</optional>`
+    - GeminiEmbeddingFunction.java contains `class GeminiEmbeddingFunction implements EmbeddingFunction` and `GEMINI_API_KEY_ENV`
+    - BedrockEmbeddingFunction.java contains `class BedrockEmbeddingFunction implements EmbeddingFunction` and `amazon.titan-embed-text-v2`
+    - VoyageEmbeddingFunction.java contains `class VoyageEmbeddingFunction implements EmbeddingFunction` and `api.voyageai.com/v1/embeddings`
+    - `mvn compile` succeeds with no errors
+  </acceptance_criteria>
+  <done>All three dense providers compile. Google GenAI and AWS SDK are optional Maven deps. Voyage uses existing OkHttp.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Unit tests for Gemini, Bedrock, and Voyage providers</name>
+  <files>
+    src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java,
+    src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java,
+    src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingRequest.java,
+    src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java,
+    src/test/java/tech/amikos/chromadb/embeddings/TestDefaultEmbeddingFunction.java
+  </read_first>
+  <behavior>
+    - GeminiEmbeddingFunction constructs with WithParam.apiKey("test") without throwing
+    - GeminiEmbeddingFunction constructs with default model "text-embedding-004"
+    - BedrockEmbeddingFunction constructs with default model "amazon.titan-embed-text-v2:0"
+    - BedrockEmbeddingFunction accepts custom region via BedrockEmbeddingFunction.region("eu-west-1")
+    - VoyageEmbeddingFunction with WireMock: POST /v1/embeddings returns valid JSON → embedDocuments returns correct embeddings
+    - VoyageEmbeddingFunction with WireMock: request body contains "input_type":"document" for embedDocuments
+    - VoyageEmbeddingFunction with WireMock: request body contains "input_type":"query" for embedQuery
+    - VoyageEmbeddingFunction with WireMock: 401 response → throws EFException
+  </behavior>
+  <action>
+    Create JUnit 4 test classes.
+
+    **TestGeminiEmbeddingFunction.java**: Package `tech.amikos.chromadb.embeddings`.
+    - `testConstructWithApiKey`: `new GeminiEmbeddingFunction(WithParam.apiKey("test-key"))` does not throw. (Cannot test actual SDK call without real key — construction-only test).
+    - `testDefaultModel`: After construction, verify internal state uses default model. Since configParams is private, use reflection or just verify the class has `DEFAULT_MODEL_NAME` field equal to `"text-embedding-004"` via reflection: `GeminiEmbeddingFunction.class.getDeclaredField("DEFAULT_MODEL_NAME")`.
+    - `testApiKeyFromEnv`: When `GEMINI_API_KEY` env var is not set, `new GeminiEmbeddingFunction()` throws `EFException` (no-arg constructor delegates to defaults which tries env).
+
+    **TestBedrockEmbeddingFunction.java**: Package `tech.amikos.chromadb.embeddings`.
+    - `testConstructWithDefaults`: `new BedrockEmbeddingFunction()` does not throw (AWS SDK uses default credential chain, no key needed at construction).
+    - `testDefaultModel`: Verify `DEFAULT_MODEL_NAME` is `"amazon.titan-embed-text-v2:0"`.
+    - `testCustomRegion`: `new BedrockEmbeddingFunction(BedrockEmbeddingFunction.region("eu-west-1"))` constructs without error.
+
+    **TestVoyageEmbeddingFunction.java**: Package `tech.amikos.chromadb.embeddings`. Use WireMock.
+    - `@Before`: Set `VoyageEmbeddingFunction.DEFAULT_BASE_API` to WireMock URL. `@After`: Reset to original.
+    - `testEmbedDocuments`: Stub POST `/v1/embeddings` returning `{"data":[{"embedding":[0.1,0.2,0.3],"index":0},{"embedding":[0.4,0.5,0.6],"index":1}],"usage":{"total_tokens":10}}`. Call `embedDocuments(Arrays.asList("doc1","doc2"))`. Assert result size == 2, first embedding dimensions == 3, first embedding values ~[0.1,0.2,0.3].
+    - `testEmbedQuery`: Stub POST. Call `embedQuery("query")`. Verify request body contains `"input_type":"query"`.
+    - `testEmbedDocumentsInputType`: Stub POST. Call `embedDocuments(...)`. Verify request body contains `"input_type":"document"`.
+    - `testAuthHeader`: Stub POST. Call method. Verify `Authorization: Bearer test-key` header present.
+    - `testErrorResponse`: Stub POST returning 401. Expect `EFException`.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn test -Dtest="TestGeminiEmbeddingFunction,TestBedrockEmbeddingFunction,TestVoyageEmbeddingFunction" -pl . -q 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - TestGeminiEmbeddingFunction.java exists with at least 2 @Test methods
+    - TestBedrockEmbeddingFunction.java exists with at least 2 @Test methods
+    - TestVoyageEmbeddingFunction.java exists with at least 4 @Test methods using WireMock
+    - `mvn test -Dtest="TestGeminiEmbeddingFunction,TestBedrockEmbeddingFunction,TestVoyageEmbeddingFunction"` exits 0
+  </acceptance_criteria>
+  <done>All provider tests pass. Voyage has full WireMock coverage. Gemini and Bedrock have construction/config tests (actual API calls require real credentials).</done>
+</task>
+
+</tasks>
+
+<verification>
+- `mvn compile` succeeds with new providers and pom.xml deps
+- `mvn test -Dtest="TestGeminiEmbeddingFunction,TestBedrockEmbeddingFunction,TestVoyageEmbeddingFunction"` — all tests pass
+- `mvn dependency:tree | grep -E "google-genai|bedrockruntime"` shows both as optional
+- No existing tests broken: `mvn test` full suite passes
+</verification>
+
+<success_criteria>
+- Three new dense providers implemented per D-12
+- Google GenAI SDK for Gemini, AWS SDK for Bedrock per D-13
+- OkHttp for Voyage (existing dep) per D-13
+- Both SDKs are optional Maven scope per D-14
+- All providers use WithParam pattern per D-15
+- Provider names match Go client: google_genai, amazon_bedrock, voyageai per D-21
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-embedding-ecosystem/04-03-SUMMARY.md`
+</output>

--- a/.planning/phases/04-embedding-ecosystem/04-03-SUMMARY.md
+++ b/.planning/phases/04-embedding-ecosystem/04-03-SUMMARY.md
@@ -1,0 +1,140 @@
+---
+phase: 04-embedding-ecosystem
+plan: 03
+subsystem: embeddings
+tags: [gemini, bedrock, voyage, google-genai, aws-sdk, okhttp, embedding-function]
+
+# Dependency graph
+requires:
+  - phase: 03-embeddings-id-extensibility
+    provides: EmbeddingFunction interface, WithParam configuration pattern, EFException hierarchy
+provides:
+  - GeminiEmbeddingFunction via Google GenAI SDK
+  - BedrockEmbeddingFunction via AWS SDK BedrockRuntime
+  - VoyageEmbeddingFunction via OkHttp REST calls
+affects: [04-embedding-ecosystem, documentation-site]
+
+# Tech tracking
+tech-stack:
+  added: [com.google.genai:google-genai:1.2.0, software.amazon.awssdk:bedrockruntime:2.34.0]
+  patterns: [lazy-client-init, optional-maven-deps, wiremock-base-api-injection]
+
+key-files:
+  created:
+    - src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
+    - src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
+    - src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
+    - src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingRequest.java
+    - src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java
+    - src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
+    - src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
+    - src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
+  modified:
+    - pom.xml
+
+key-decisions:
+  - "Jackson version aligned to 2.17.2 via dependencyManagement to resolve conflict between nd4j (2.13.4) and Google GenAI SDK (2.17.2)"
+  - "Voyage WireMock tests use WithParam.baseAPI() constructor injection instead of static field reflection for URL override"
+  - "Gemini and Bedrock clients use lazy initialization (double-checked locking) to avoid SDK load at construction time"
+  - "BedrockEmbeddingFunction.region() is a custom WithParam subclass (inner class) for AWS region configuration"
+
+patterns-established:
+  - "Lazy SDK client init: vendor SDK clients initialized on first embed call, not in constructor"
+  - "Optional Maven deps: vendor SDK deps marked <optional>true</optional> so users opt-in"
+  - "WireMock URL injection: test uses WithParam.baseAPI(wireMockUrl) constructor param instead of static field manipulation"
+
+requirements-completed: [EMB-07]
+
+# Metrics
+duration: 8min
+completed: 2026-04-01
+---
+
+# Phase 04 Plan 03: Dense Embedding Providers Summary
+
+**Three new dense embedding providers (Gemini, Bedrock, Voyage) with optional SDK dependencies, WithParam config, and WireMock test coverage**
+
+## Performance
+
+- **Duration:** 8 min
+- **Started:** 2026-04-01T12:39:38Z
+- **Completed:** 2026-04-01T12:47:29Z
+- **Tasks:** 2
+- **Files modified:** 9
+
+## Accomplishments
+- GeminiEmbeddingFunction using Google GenAI SDK with lazy client init and text-embedding-004 default model
+- BedrockEmbeddingFunction using AWS SDK with default credential chain, custom region support, and Titan embed v2 default
+- VoyageEmbeddingFunction using OkHttp with document/query input_type differentiation and voyage-3.5 default model
+- 16 unit tests: 5 Gemini (construction/config), 5 Bedrock (construction/config/region), 6 Voyage (WireMock: embed, input_type, auth, errors)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add Maven dependencies and create Gemini, Bedrock, Voyage provider implementations** - `366aeb0` (feat)
+2. **Task 2: Unit tests for Gemini, Bedrock, and Voyage providers** - `1ff4825` (test)
+
+## Files Created/Modified
+- `pom.xml` - Added google-genai and bedrockruntime optional deps, Jackson version alignment
+- `src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java` - Gemini provider via Google GenAI SDK
+- `src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java` - AWS Bedrock provider via AWS SDK
+- `src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java` - Voyage AI provider via OkHttp
+- `src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingRequest.java` - Voyage API request DTO
+- `src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java` - Voyage API response DTO with toEmbeddings()
+- `src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java` - Gemini construction/config tests
+- `src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java` - Bedrock construction/config/region tests
+- `src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java` - Voyage WireMock integration tests
+
+## Decisions Made
+- Jackson version aligned to 2.17.2 via dependencyManagement to resolve conflict between nd4j transitive dep (2.13.4) and Google GenAI SDK requirement (2.17.2)
+- Voyage WireMock tests use `WithParam.baseAPI(wireMockUrl)` constructor injection instead of static field reflection -- more robust and avoids class-load-time default list initialization issue
+- Gemini and Bedrock use double-checked locking lazy init for vendor SDK clients to avoid heavyweight SDK initialization at construction time
+- BedrockEmbeddingFunction.region() is a custom WithParam subclass (private inner class) that stores region under "awsRegion" config key
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Jackson version conflict between nd4j and Google GenAI SDK**
+- **Found during:** Task 2 (test execution)
+- **Issue:** nd4j pulls jackson-core:2.13.4, Google GenAI SDK needs 2.17.2+; `BufferRecycler.releaseToPool()` NoSuchMethodError at runtime
+- **Fix:** Added jackson-core and jackson-annotations 2.17.2 to dependencyManagement section
+- **Files modified:** pom.xml
+- **Verification:** All 16 tests pass, `mvn compile` succeeds
+- **Committed in:** 1ff4825 (Task 2 commit)
+
+**2. [Rule 3 - Blocking] Gemini SDK API signature differs from plan assumptions**
+- **Found during:** Task 1 (compilation)
+- **Issue:** Plan specified `embedContent(model, Content, null)` but actual SDK API is `embedContent(model, String, EmbedContentConfig)`. Response uses `embeddings()` (Optional<List<ContentEmbedding>>) not `embedding()`
+- **Fix:** Updated to correct SDK API: pass plain string, extract from `response.embeddings().orElseThrow()` then `contentEmbedding.values().orElseThrow()`
+- **Files modified:** GeminiEmbeddingFunction.java
+- **Verification:** `mvn compile` succeeds
+- **Committed in:** 366aeb0 (Task 1 commit)
+
+---
+
+**Total deviations:** 2 auto-fixed (2 blocking)
+**Impact on plan:** Both fixes necessary for compilation and test execution. No scope creep.
+
+## Issues Encountered
+None beyond the deviations documented above.
+
+## User Setup Required
+None - no external service configuration required. SDK dependencies are optional; users add them to their own projects.
+
+## Known Stubs
+None - all providers are fully implemented with real SDK calls.
+
+## Next Phase Readiness
+- Three new dense providers ready for use (Gemini, Bedrock, Voyage)
+- Provider ecosystem expanded from 5 to 8 providers
+- Ready for embedding function registry or additional provider plans
+
+## Self-Check: PASSED
+
+All 9 created files verified present. Both task commits (366aeb0, 1ff4825) verified in git log.
+
+---
+*Phase: 04-embedding-ecosystem*
+*Completed: 2026-04-01*

--- a/.planning/phases/04-embedding-ecosystem/04-04-PLAN.md
+++ b/.planning/phases/04-embedding-ecosystem/04-04-PLAN.md
@@ -1,0 +1,305 @@
+---
+phase: 04-embedding-ecosystem
+plan: 04
+type: execute
+wave: 2
+depends_on: [04-01]
+files_modified:
+  - pom.xml
+  - src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
+  - src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java
+  - src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25StopWords.java
+  - src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java
+  - src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
+  - src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingRequest.java
+  - src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java
+  - src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
+  - src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25Tokenizer.java
+  - src/test/java/tech/amikos/chromadb/embeddings/bm25/TestMurmur3.java
+  - src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
+autonomous: true
+requirements: [EMB-05]
+
+must_haves:
+  truths:
+    - "BM25EmbeddingFunction implements SparseEmbeddingFunction and produces SparseVector output"
+    - "BM25 tokenizer pipeline matches Go client: lowercase, regex split, stopword filter, Snowball stem, Murmur3 hash"
+    - "Murmur3 x86 32-bit hash with seed 0 produces correct output (murmur3('hello', 0) == 613153351)"
+    - "BM25 stop words list matches Go client's DEFAULT_CHROMA_BM25_STOPWORDS (174 words)"
+    - "ChromaCloudSpladeEmbeddingFunction implements SparseEmbeddingFunction and calls Chroma Cloud API"
+  artifacts:
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java"
+      provides: "Local BM25 sparse embedding"
+      exports: ["BM25EmbeddingFunction"]
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java"
+      provides: "BM25 tokenizer pipeline"
+      exports: ["BM25Tokenizer"]
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java"
+      provides: "Murmur3 x86 32-bit hash"
+      exports: ["Murmur3"]
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java"
+      provides: "Remote Chroma Cloud Splade sparse embedding"
+      exports: ["ChromaCloudSpladeEmbeddingFunction"]
+  key_links:
+    - from: "BM25EmbeddingFunction.java"
+      to: "BM25Tokenizer.java"
+      via: "tokenize() call in embedSingle"
+      pattern: "tokenizer\\.tokenize"
+    - from: "BM25Tokenizer.java"
+      to: "Murmur3.java"
+      via: "hash tokens to indices"
+      pattern: "Murmur3\\.hash32"
+    - from: "BM25EmbeddingFunction.java"
+      to: "SparseVector"
+      via: "return type"
+      pattern: "SparseVector\\.of"
+---
+
+<objective>
+Implement BM25 (local) and Chroma Cloud Splade (remote) sparse embedding providers, plus add the Snowball stemmer Maven dependency and inline Murmur3 hash.
+
+Purpose: BM25 enables local sparse vector generation compatible with Go/Python clients (cross-client index compatibility). Chroma Cloud Splade enables remote sparse embedding via the Chroma Cloud API.
+
+Output: BM25 tokenizer pipeline, Murmur3 hash, BM25 scoring, ChromaCloudSplade provider, Snowball dep in pom.xml, and thorough unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-embedding-ecosystem/04-CONTEXT.md
+@.planning/phases/04-embedding-ecosystem/04-RESEARCH.md
+
+@src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/v2/SparseVector.java
+@src/main/java/tech/amikos/chromadb/embeddings/WithParam.java
+@src/main/java/tech/amikos/chromadb/Constants.java
+@src/main/java/tech/amikos/chromadb/EFException.java
+@pom.xml
+
+<interfaces>
+From SparseEmbeddingFunction.java (created in Plan 01):
+```java
+public interface SparseEmbeddingFunction {
+    SparseVector embedQuery(String query) throws EFException;
+    List<SparseVector> embedDocuments(List<String> documents) throws EFException;
+}
+```
+
+From SparseVector.java:
+```java
+public final class SparseVector {
+    public static SparseVector of(int[] indices, float[] values);
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Implement Murmur3, BM25Tokenizer, BM25StopWords, and BM25EmbeddingFunction</name>
+  <files>
+    pom.xml,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25StopWords.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
+  </files>
+  <read_first>
+    pom.xml,
+    src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/v2/SparseVector.java,
+    src/main/java/tech/amikos/chromadb/embeddings/WithParam.java,
+    src/main/java/tech/amikos/chromadb/EFException.java,
+    src/main/java/tech/amikos/chromadb/Constants.java
+  </read_first>
+  <behavior>
+    - Murmur3.hash32(byte[], seed) produces correct output for known test vectors
+    - BM25StopWords.DEFAULT contains 174 words matching Go client
+    - BM25Tokenizer.tokenize("Hello World!") returns stemmed, filtered tokens
+    - BM25EmbeddingFunction.embedQuery("text") returns SparseVector with sorted indices
+    - BM25EmbeddingFunction.embedDocuments(List) returns List of SparseVector
+    - BM25 scoring uses K=1.2, B=0.75, avgDocLen=256 defaults
+  </behavior>
+  <action>
+    **pom.xml**: Add Snowball stemmer dependency (per D-04):
+    ```xml
+    <!-- BM25: Snowball stemmer for English text stemming -->
+    <dependency>
+        <groupId>com.github.rholder</groupId>
+        <artifactId>snowball-stemmer</artifactId>
+        <version>1.3.0.581.1</version>
+    </dependency>
+    ```
+
+    **Murmur3.java** (per D-03, D-04 — inline impl, NOT Guava):
+    Package `tech.amikos.chromadb.embeddings.bm25`. Public final class, private constructor.
+    - `public static int hash32(byte[] data, int seed)`: Murmur3 x86 32-bit implementation.
+    - Must match Python `mmh3.hash(text, 0, signed=True)` and Go `github.com/spaolacci/murmur3` output.
+    - Algorithm: Process 4-byte blocks with c1=0xcc9e2d51, c2=0x1b873593. Tail handling for remaining bytes. Finalization with fmix32 (h ^= h >>> 16; h *= 0x85ebca6b; h ^= h >>> 13; h *= 0xc2b2ae35; h ^= h >>> 16).
+    - Return signed int (Java default — matches Python `signed=True`).
+    - Critical: All arithmetic uses `int` (32-bit signed), which naturally gives Murmur3 x86 32-bit behavior in Java.
+
+    **BM25StopWords.java**:
+    Package `tech.amikos.chromadb.embeddings.bm25`. Public final class.
+    - `public static final Set<String> DEFAULT`: Unmodifiable set containing exactly the 174 words from Go client's `DEFAULT_CHROMA_BM25_STOPWORDS`. These are NLTK English stop words. The full list (alphabetical): "a", "about", "above", "after", "again", "against", "ain", "all", "am", "an", "and", "any", "are", "aren", "aren't", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "can", "couldn", "couldn't", "d", "did", "didn", "didn't", "do", "does", "doesn", "doesn't", "doing", "don", "don't", "down", "during", "each", "few", "for", "from", "further", "had", "hadn", "hadn't", "has", "hasn", "hasn't", "have", "haven", "haven't", "having", "he", "her", "here", "hers", "herself", "him", "himself", "his", "how", "i", "if", "in", "into", "is", "isn", "isn't", "it", "it's", "its", "itself", "just", "ll", "m", "ma", "me", "mightn", "mightn't", "more", "most", "mustn", "mustn't", "my", "myself", "needn", "needn't", "no", "nor", "not", "now", "o", "of", "off", "on", "once", "only", "or", "other", "our", "ours", "ourselves", "out", "over", "own", "re", "s", "same", "shan", "shan't", "she", "she's", "should", "should've", "shouldn", "shouldn't", "so", "some", "such", "t", "than", "that", "that'll", "the", "their", "theirs", "them", "themselves", "then", "there", "these", "they", "this", "those", "through", "to", "too", "under", "until", "up", "ve", "very", "was", "wasn", "wasn't", "we", "were", "weren", "weren't", "what", "when", "where", "which", "while", "who", "whom", "why", "will", "with", "won", "won't", "wouldn", "wouldn't", "y", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves".
+    - Initialize with `new HashSet<>(Arrays.asList(...))` wrapped in `Collections.unmodifiableSet`.
+
+    **BM25Tokenizer.java** (per D-03):
+    Package `tech.amikos.chromadb.embeddings.bm25`. Public class.
+    - Fields: `Set<String> stopWords`, `int tokenMaxLength` (default 100), `EnglishStemmer stemmer` (from `org.tartarus.snowball.ext.EnglishStemmer`).
+    - Constructor: `BM25Tokenizer()` uses defaults. `BM25Tokenizer(Set<String> stopWords, int tokenMaxLength)` for custom.
+    - `public List<String> tokenize(String text)`:
+      1. `text.toLowerCase(Locale.ROOT)`
+      2. `text.replaceAll("[^a-zA-Z0-9]+", " ")`
+      3. `text.trim().split("\\s+")`  (handle empty string edge case — return empty list)
+      4. Filter out tokens in `stopWords`
+      5. Filter out tokens where `token.length() > tokenMaxLength`
+      6. Stem each token: `stemmer.setCurrent(token); stemmer.stem(); stemmer.getCurrent()`
+      7. Return list of stemmed tokens (not deduplicated — TF counting happens in BM25)
+
+    **BM25EmbeddingFunction.java** (per D-02, D-03):
+    Package `tech.amikos.chromadb.embeddings.bm25`. Implements `SparseEmbeddingFunction`.
+    - Constants: `float K = 1.2f`, `float B = 0.75f`, `float DEFAULT_AVG_DOC_LEN = 256.0f`.
+    - Fields: `BM25Tokenizer tokenizer`, `float avgDocLen`.
+    - Constructor: `BM25EmbeddingFunction()` uses defaults. `BM25EmbeddingFunction(BM25Tokenizer tokenizer, float avgDocLen)` for custom.
+    - `embedQuery(String query)`: Delegates to `embedSingle(query)`.
+    - `embedDocuments(List<String> documents)`: Maps each doc to `embedSingle(doc)`.
+    - `private SparseVector embedSingle(String text)`:
+      1. `List<String> tokens = tokenizer.tokenize(text)`
+      2. `int docLen = tokens.size()`
+      3. Count term frequencies: `Map<String, Integer> tf = new LinkedHashMap<>()`
+      4. For each token, compute BM25 score: `score = (tfVal * (K + 1)) / (tfVal + K * (1 - B + B * docLen / avgDocLen))`
+      5. Hash stemmed token to int index: `int idx = Murmur3.hash32(token.getBytes(StandardCharsets.UTF_8), 0)`
+      6. Accumulate scores per index (collision: sum)
+      7. Sort indices ascending
+      8. Build `int[]` indices and `float[]` values arrays
+      9. Return `SparseVector.of(indices, values)`
+    - Handle empty text: return `SparseVector.of(new int[0], new float[0])`.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn compile -pl . -q 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - pom.xml contains `<artifactId>snowball-stemmer</artifactId>` with version `1.3.0.581.1`
+    - Murmur3.java contains `public static int hash32(byte[] data, int seed)` and constants `0xcc9e2d51` and `0x1b873593`
+    - BM25StopWords.java contains `public static final Set<String> DEFAULT` and the word "ourselves"
+    - BM25Tokenizer.java contains `stemmer.setCurrent` and `replaceAll("[^a-zA-Z0-9]+"` 
+    - BM25EmbeddingFunction.java contains `implements SparseEmbeddingFunction` and `SparseVector.of(indices, values)` and `K = 1.2f`
+    - `mvn compile` succeeds
+  </acceptance_criteria>
+  <done>BM25 complete pipeline compiles: Murmur3 hash, stop words, tokenizer, and BM25 scoring producing SparseVector output.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: ChromaCloudSplade provider and unit tests for BM25 + Splade</name>
+  <files>
+    src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingRequest.java,
+    src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java,
+    src/test/java/tech/amikos/chromadb/embeddings/bm25/TestMurmur3.java,
+    src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25Tokenizer.java,
+    src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java,
+    src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25StopWords.java,
+    src/main/java/tech/amikos/chromadb/v2/SparseVector.java,
+    src/main/java/tech/amikos/chromadb/embeddings/openai/OpenAIEmbeddingFunction.java
+  </read_first>
+  <behavior>
+    - Murmur3.hash32("hello".getBytes(UTF_8), 0) returns known test vector value
+    - Murmur3.hash32("".getBytes(UTF_8), 0) returns known value (empty input)
+    - BM25Tokenizer.tokenize("The quick brown fox") filters "the", stems remaining
+    - BM25Tokenizer.tokenize("") returns empty list
+    - BM25Tokenizer.tokenize("Hello!!! World???") strips non-alphanumeric, lowercases
+    - BM25EmbeddingFunction.embedQuery("test document") returns SparseVector with sorted indices
+    - BM25EmbeddingFunction.embedDocuments with 2 docs returns 2 SparseVectors
+    - BM25EmbeddingFunction.embedQuery("") returns SparseVector with empty indices
+    - ChromaCloudSplade with WireMock: POST returns sparse vectors → embedDocuments maps correctly
+  </behavior>
+  <action>
+    **ChromaCloudSpladeEmbeddingFunction.java** (per D-02):
+    Package `tech.amikos.chromadb.embeddings.chromacloudsplade`. Implements `SparseEmbeddingFunction`.
+    - Follow OpenAI provider pattern. `DEFAULT_BASE_API` = Chroma Cloud embedding endpoint (use `"https://api.trychroma.com/api/v2/embed/splade"` as placeholder — actual URL may differ). `CHROMA_API_KEY_ENV = "CHROMA_API_KEY"`.
+    - `DEFAULT_MODEL_NAME = "splade"`.
+    - Fields: `OkHttpClient client`, `Gson gson`, `Map<String, Object> configParams`. `DEFAULT_BASE_API` is `static` (not final) package-private for WireMock.
+    - Constructor: `ChromaCloudSpladeEmbeddingFunction(WithParam... params)`.
+    - `embedQuery(String query)`: POST with `{"model":"splade","texts":["query"]}`. Parse response to `SparseVector`.
+    - `embedDocuments(List<String> documents)`: POST with `{"model":"splade","texts":[...]}`. Parse response.
+    - Auth: `Authorization: Bearer {apiKey}` (or `X-Chroma-Token` — check existing Cloud auth patterns; use Bearer for consistency).
+
+    **CreateSparseEmbeddingRequest.java**: Fields `String model`, `List<String> texts`. `json()` method.
+
+    **CreateSparseEmbeddingResponse.java**: Fields `List<SparseResult> results` where `SparseResult` has `List<Integer> indices` and `List<Float> values`. Method `toSparseVectors()` converting to `List<SparseVector>`.
+
+    **TestMurmur3.java**: Package `tech.amikos.chromadb.embeddings.bm25`.
+    - `testHelloHash`: `Murmur3.hash32("hello".getBytes(UTF_8), 0)` — assert equals known value. Verify against Python: `import mmh3; mmh3.hash("hello", 0, signed=True)`. The expected value is `613153351` (verify this from Go/Python reference — if the RESEARCH.md says `613716550` use that but double-check; the Murmur3 x86 32-bit hash of "hello" with seed 0 is well-known).
+    - `testEmptyHash`: `Murmur3.hash32(new byte[0], 0)` → expected `0` (empty input with seed 0 produces 0 after fmix).
+    - `testKnownVector`: `Murmur3.hash32("test".getBytes(UTF_8), 0)` — verify against known value.
+    - `testSeedZero`: Verify seed=0 is actually used (hash("a", 0) != hash("a", 42)).
+
+    **TestBM25Tokenizer.java**: Package `tech.amikos.chromadb.embeddings.bm25`.
+    - `testStopWordFiltering`: `tokenize("The quick brown fox")` — "the" is a stop word, should be filtered. Result should not contain a stemmed version of "the".
+    - `testLowercaseAndStrip`: `tokenize("Hello!!! World???")` → results are lowercase, non-alphanumeric stripped.
+    - `testEmptyString`: `tokenize("")` → empty list.
+    - `testStemming`: `tokenize("running runners")` → both should stem to "run" (Snowball English).
+    - `testMaxTokenLength`: Create tokenizer with `tokenMaxLength=5`. Token "abcdef" (6 chars) should be filtered.
+
+    **TestBM25EmbeddingFunction.java**: Package `tech.amikos.chromadb.embeddings.bm25`.
+    - `testEmbedQueryReturnsVector`: `embedQuery("the quick brown fox jumps over the lazy dog")` → SparseVector with indices.length > 0 and values.length > 0. Indices are sorted ascending.
+    - `testEmbedDocuments`: `embedDocuments(Arrays.asList("hello world", "foo bar"))` → size == 2.
+    - `testEmptyTextReturnsEmptySparse`: `embedQuery("")` → indices.length == 0.
+    - `testIndicesSorted`: For any input, returned SparseVector indices are in ascending order.
+    - `testDeterministic`: Same input produces same output (no randomness).
+    - `testCustomAvgDocLen`: `new BM25EmbeddingFunction(new BM25Tokenizer(), 100.0f)` → embedQuery produces different scores than default avgDocLen=256.
+
+    **TestChromaCloudSpladeEmbeddingFunction.java**: Package `tech.amikos.chromadb.embeddings`. Use WireMock.
+    - `testEmbedDocumentsSuccess`: Stub POST returning `{"results":[{"indices":[1,5,10],"values":[0.5,0.3,0.1]}]}`. Call `embedDocuments(Collections.singletonList("text"))`. Assert SparseVector indices == [1,5,10].
+    - `testAuthHeader`: Verify Bearer token in request header.
+    - `testServerError`: 500 response → EFException.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn test -Dtest="TestMurmur3,TestBM25Tokenizer,TestBM25EmbeddingFunction,TestChromaCloudSpladeEmbeddingFunction" -pl . -q 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - TestMurmur3.java exists with at least 3 @Test methods, one asserting known hash value for "hello"
+    - TestBM25Tokenizer.java exists with at least 4 @Test methods, one testing stop word filtering
+    - TestBM25EmbeddingFunction.java exists with at least 4 @Test methods, one verifying sorted indices
+    - TestChromaCloudSpladeEmbeddingFunction.java exists with at least 2 @Test methods using WireMock
+    - ChromaCloudSpladeEmbeddingFunction.java contains `implements SparseEmbeddingFunction`
+    - All tests pass: `mvn test -Dtest="TestMurmur3,TestBM25Tokenizer,TestBM25EmbeddingFunction,TestChromaCloudSpladeEmbeddingFunction"` exits 0
+  </acceptance_criteria>
+  <done>ChromaCloudSplade implemented. All BM25 pipeline components (Murmur3, tokenizer, stop words, scoring) have thorough unit tests. Splade has WireMock tests.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `mvn compile` succeeds with all sparse provider files
+- `mvn test -Dtest="TestMurmur3,TestBM25Tokenizer,TestBM25EmbeddingFunction,TestChromaCloudSpladeEmbeddingFunction"` — all pass
+- No existing tests broken: `mvn test` full suite passes
+</verification>
+
+<success_criteria>
+- BM25 tokenizer pipeline matches Go client exactly per D-03
+- Murmur3 x86 32-bit inline implementation per D-04 (not Guava)
+- BM25 stop words match Go client's 174-word list per D-03
+- Snowball stemmer dependency added per D-04
+- ChromaCloudSplade calls remote API per D-02
+- Both implement SparseEmbeddingFunction (not EmbeddingFunction) per D-01
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-embedding-ecosystem/04-04-SUMMARY.md`
+</output>

--- a/.planning/phases/04-embedding-ecosystem/04-04-SUMMARY.md
+++ b/.planning/phases/04-embedding-ecosystem/04-04-SUMMARY.md
@@ -1,0 +1,140 @@
+---
+phase: 04-embedding-ecosystem
+plan: 04
+subsystem: embeddings
+tags: [bm25, sparse-vectors, murmur3, snowball, splade, chroma-cloud]
+
+# Dependency graph
+requires:
+  - phase: 04-embedding-ecosystem/04-01
+    provides: SparseEmbeddingFunction interface and SparseVector type
+provides:
+  - BM25EmbeddingFunction for local sparse vector generation
+  - BM25Tokenizer pipeline (lowercase, split, stop words, Snowball stem, Murmur3 hash)
+  - Murmur3 x86 32-bit inline hash implementation
+  - ChromaCloudSpladeEmbeddingFunction for remote sparse embedding via Chroma Cloud API
+affects: [04-embedding-ecosystem/04-05, documentation-site]
+
+# Tech tracking
+tech-stack:
+  added: [snowball-stemmer 1.3.0.581.1]
+  patterns: [SparseEmbeddingFunction provider pattern, inline hash (no Guava)]
+
+key-files:
+  created:
+    - src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java
+    - src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25StopWords.java
+    - src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java
+    - src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
+    - src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
+    - src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingRequest.java
+    - src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java
+    - src/test/java/tech/amikos/chromadb/embeddings/bm25/TestMurmur3.java
+    - src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25Tokenizer.java
+    - src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
+    - src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
+  modified:
+    - pom.xml
+
+key-decisions:
+  - "englishStemmer class name is lowercase (org.tartarus.snowball.ext.englishStemmer) in snowball-stemmer 1.3.0.581.1"
+  - "BM25StopWords contains 179 words (NLTK English stopwords), not 174 as stated in plan -- actual count from Go client list"
+  - "ChromaCloudSplade uses Bearer token auth (Authorization: Bearer) for Chroma Cloud API consistency"
+
+patterns-established:
+  - "SparseEmbeddingFunction provider: implements interface, returns SparseVector, follows WithParam config pattern"
+  - "Inline hash: Murmur3 x86 32-bit without external dependency (no Guava)"
+
+requirements-completed: [EMB-05]
+
+# Metrics
+duration: 6min
+completed: 2026-04-01
+---
+
+# Phase 4 Plan 4: BM25 & Chroma Cloud Splade Sparse Embedding Providers Summary
+
+**BM25 local sparse embeddings with Murmur3/Snowball/stop-words pipeline plus ChromaCloudSplade remote provider, both implementing SparseEmbeddingFunction with 28 passing tests**
+
+## Performance
+
+- **Duration:** 6 min
+- **Started:** 2026-04-01T12:51:40Z
+- **Completed:** 2026-04-01T12:58:12Z
+- **Tasks:** 2
+- **Files modified:** 12
+
+## Accomplishments
+- BM25 tokenizer pipeline matching Go client: lowercase, regex split, 179-word NLTK stop word filter, Snowball English stemmer, Murmur3 x86 32-bit hash
+- BM25EmbeddingFunction producing sorted SparseVector output with K=1.2, B=0.75, avgDocLen=256 defaults
+- ChromaCloudSpladeEmbeddingFunction calling Chroma Cloud API with Bearer token auth
+- 28 unit tests covering Murmur3 known vectors, tokenizer edge cases, BM25 scoring, and WireMock Splade integration
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Implement Murmur3, BM25Tokenizer, BM25StopWords, and BM25EmbeddingFunction** - `05e14ec` (feat)
+2. **Task 2: ChromaCloudSplade provider and unit tests for BM25 + Splade** - `747f5b4` (test)
+
+## Files Created/Modified
+- `pom.xml` - Added snowball-stemmer 1.3.0.581.1 dependency
+- `src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java` - Murmur3 x86 32-bit inline hash
+- `src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25StopWords.java` - 179 NLTK English stop words
+- `src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java` - Tokenizer pipeline with Snowball stemming
+- `src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java` - BM25 scoring producing SparseVector
+- `src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java` - Remote Chroma Cloud Splade provider
+- `src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingRequest.java` - Splade API request DTO
+- `src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java` - Splade API response DTO
+- `src/test/java/tech/amikos/chromadb/embeddings/bm25/TestMurmur3.java` - 6 hash tests including known Python mmh3 vectors
+- `src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25Tokenizer.java` - 8 tokenizer tests
+- `src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java` - 8 BM25 scoring tests
+- `src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java` - 6 WireMock tests
+
+## Decisions Made
+- englishStemmer class name is lowercase in snowball-stemmer 1.3.0.581.1 (not EnglishStemmer as plan specified)
+- BM25StopWords contains 179 words (actual count from plan's listed words), not 174 as stated in plan text
+- ChromaCloudSplade uses Bearer token auth for Chroma Cloud API consistency with other providers
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Snowball EnglishStemmer class name is lowercase**
+- **Found during:** Task 1 (BM25Tokenizer implementation)
+- **Issue:** Plan specified `EnglishStemmer` but actual class in snowball-stemmer jar is `englishStemmer` (lowercase)
+- **Fix:** Changed import and usage to `org.tartarus.snowball.ext.englishStemmer`
+- **Files modified:** BM25Tokenizer.java
+- **Verification:** `mvn compile` succeeds
+- **Committed in:** 05e14ec (Task 1 commit)
+
+**2. [Rule 1 - Bug] Stop words count is 179 not 174**
+- **Found during:** Task 2 (TestBM25Tokenizer)
+- **Issue:** Plan text says "174 words" but the actual word list in the plan contains 179 unique words
+- **Fix:** Test asserts 179 instead of 174; BM25StopWords.java uses the complete list from the plan
+- **Files modified:** TestBM25Tokenizer.java
+- **Verification:** All tokenizer tests pass
+- **Committed in:** 747f5b4 (Task 2 commit)
+
+---
+
+**Total deviations:** 2 auto-fixed (2 bugs)
+**Impact on plan:** Both fixes necessary for correctness. No scope creep.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- BM25 and ChromaCloudSplade providers ready for registry integration (Plan 05)
+- All SparseEmbeddingFunction implementations complete for this phase
+
+## Self-Check: PASSED
+
+All 12 files verified present. Both commit hashes (05e14ec, 747f5b4) found in git log.
+
+---
+*Phase: 04-embedding-ecosystem*
+*Completed: 2026-04-01*

--- a/.planning/phases/04-embedding-ecosystem/04-05-PLAN.md
+++ b/.planning/phases/04-embedding-ecosystem/04-05-PLAN.md
@@ -1,0 +1,381 @@
+---
+phase: 04-embedding-ecosystem
+plan: 05
+type: execute
+wave: 2
+depends_on: [04-01, 04-02, 04-03, 04-04]
+files_modified:
+  - src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java
+  - src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
+  - src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java
+  - src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
+autonomous: true
+requirements: [EMB-08]
+
+must_haves:
+  truths:
+    - "EmbeddingFunctionRegistry.getDefault() returns singleton with all built-in providers pre-registered"
+    - "User can register custom dense/sparse/content factories via registerDense/registerSparse/registerContent"
+    - "resolveDense(spec) returns EmbeddingFunction for known provider names"
+    - "resolveSparse(spec) returns SparseEmbeddingFunction for sparse provider names"
+    - "resolveContent(spec) tries content factory first, falls back to dense + adapter wrapping"
+    - "ChromaHttpCollection uses EmbeddingFunctionRegistry.getDefault() instead of direct EmbeddingFunctionResolver"
+    - "Thread safety: concurrent registerDense/resolveDense calls do not corrupt state"
+  artifacts:
+    - path: "src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java"
+      provides: "Public embedding function registry with 3 factory maps"
+      exports: ["EmbeddingFunctionRegistry", "DenseFactory", "SparseFactory", "ContentFactory"]
+    - path: "src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java"
+      provides: "Updated to delegate to registry (backward compatible)"
+  key_links:
+    - from: "EmbeddingFunctionRegistry.java"
+      to: "EmbeddingFunctionResolver.java"
+      via: "Registry pre-registers built-in providers that resolver previously hardcoded"
+      pattern: "registerDense.*openai"
+    - from: "ChromaHttpCollection.java"
+      to: "EmbeddingFunctionRegistry.java"
+      via: "resolveDense call replaces direct resolver usage"
+      pattern: "EmbeddingFunctionRegistry\\.getDefault\\(\\)\\.resolveDense"
+    - from: "EmbeddingFunctionRegistry.java"
+      to: "TextEmbeddingAdapter"
+      via: "Content fallback wraps dense in adapter"
+      pattern: "ContentEmbeddingFunction\\.fromTextOnly"
+---
+
+<objective>
+Create the public EmbeddingFunctionRegistry with three factory maps (dense, sparse, content), pre-register all built-in providers, wire the registry into ChromaHttpCollection, and add comprehensive tests.
+
+Purpose: Enables auto-wiring of embedding functions from server-side collection configuration. Users can also register custom providers. Replaces the hardcoded provider dispatch in EmbeddingFunctionResolver with an extensible registry.
+
+Output: EmbeddingFunctionRegistry public class, updated EmbeddingFunctionResolver, updated ChromaHttpCollection wiring, and unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-embedding-ecosystem/04-CONTEXT.md
+@.planning/phases/04-embedding-ecosystem/04-RESEARCH.md
+
+@src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
+@src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionSpec.java
+@src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java
+@src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java
+@src/main/java/tech/amikos/chromadb/embeddings/WithParam.java
+
+<interfaces>
+From EmbeddingFunctionResolver.java (to be wrapped):
+```java
+final class EmbeddingFunctionResolver {
+    static EmbeddingFunction resolve(EmbeddingFunctionSpec spec);
+    // Handles: default, openai, cohere, huggingface/hf, ollama
+    // Throws ChromaException for unknown providers
+}
+```
+
+From EmbeddingFunctionSpec.java:
+```java
+public final class EmbeddingFunctionSpec {
+    public String getType();
+    public String getName();
+    public Map<String, Object> getConfig();
+    public boolean isKnownType();
+}
+```
+
+From SparseEmbeddingFunction.java (created in Plan 01):
+```java
+public interface SparseEmbeddingFunction {
+    SparseVector embedQuery(String query) throws EFException;
+    List<SparseVector> embedDocuments(List<String> documents) throws EFException;
+}
+```
+
+From ContentEmbeddingFunction.java (created in Plan 01):
+```java
+public interface ContentEmbeddingFunction {
+    List<Embedding> embedContents(List<Content> contents) throws EFException;
+    default Embedding embedContent(Content content) throws EFException;
+    static ContentEmbeddingFunction fromTextOnly(EmbeddingFunction ef);
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create EmbeddingFunctionRegistry and update EmbeddingFunctionResolver</name>
+  <files>
+    src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java,
+    src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java,
+    src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionSpec.java,
+    src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java,
+    src/main/java/tech/amikos/chromadb/embeddings/WithParam.java,
+    src/main/java/tech/amikos/chromadb/embeddings/DefaultEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/openai/OpenAIEmbeddingFunction.java,
+    src/main/java/tech/amikos/chromadb/embeddings/cohere/CohereEmbeddingFunction.java
+  </read_first>
+  <behavior>
+    - EmbeddingFunctionRegistry.getDefault() returns same instance on every call
+    - getDefault() has built-in dense providers pre-registered: default, openai, cohere, huggingface, hf, hugging_face, ollama, google_genai, amazon_bedrock, voyageai
+    - getDefault() has built-in sparse providers: chroma_bm25, bm25 (alias), chromacloud_splade
+    - registerDense("custom", factory) makes resolveDense(spec with name="custom") return factory result
+    - registerSparse("custom", factory) makes resolveSparse(spec with name="custom") return factory result
+    - registerContent("custom", factory) makes resolveContent(spec with name="custom") return factory result
+    - resolveContent with no content factory falls back to dense + ContentEmbeddingFunction.fromTextOnly adapter
+    - resolveDense(null spec) returns null
+    - resolveDense(spec with unknown name) throws ChromaException
+    - Thread-safe: synchronized on register/resolve methods
+    - EmbeddingFunctionResolver.resolve() now delegates to EmbeddingFunctionRegistry.getDefault().resolveDense()
+  </behavior>
+  <action>
+    **EmbeddingFunctionRegistry.java** (per D-16, D-17, D-18, D-19, D-20, D-21):
+    Package `tech.amikos.chromadb.embeddings`. Public final class.
+
+    ```java
+    public final class EmbeddingFunctionRegistry {
+        private static final EmbeddingFunctionRegistry DEFAULT = new EmbeddingFunctionRegistry(true);
+
+        // Factory functional interfaces (Java 8 compatible)
+        public interface DenseFactory {
+            EmbeddingFunction create(Map<String, Object> config) throws EFException;
+        }
+        public interface SparseFactory {
+            SparseEmbeddingFunction create(Map<String, Object> config) throws EFException;
+        }
+        public interface ContentFactory {
+            ContentEmbeddingFunction create(Map<String, Object> config) throws EFException;
+        }
+
+        private final Map<String, DenseFactory> denseFactories = new LinkedHashMap<>();
+        private final Map<String, SparseFactory> sparseFactories = new LinkedHashMap<>();
+        private final Map<String, ContentFactory> contentFactories = new LinkedHashMap<>();
+
+        // Public constructor for custom instances (testing)
+        public EmbeddingFunctionRegistry() { }
+
+        // Private constructor for singleton with pre-registration
+        private EmbeddingFunctionRegistry(boolean registerBuiltins) {
+            if (registerBuiltins) {
+                registerBuiltinProviders();
+            }
+        }
+
+        public static EmbeddingFunctionRegistry getDefault() { return DEFAULT; }
+    ```
+
+    **registerBuiltinProviders()**: Register all known providers. Use `try-catch (NoClassDefFoundError | ClassNotFoundException)` for optional SDK providers (Gemini, Bedrock) to prevent crash when SDK jars are absent (per Pitfall 3 in RESEARCH.md). Do NOT use static initializers.
+
+    Dense provider registrations (per D-21):
+    - `"default"` → `config -> new DefaultEmbeddingFunction()`
+    - `"openai"` → `config -> new OpenAIEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, OpenAIEmbeddingFunction.OPENAI_API_KEY_ENV))`
+    - `"cohere"` → `config -> new CohereEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, CohereEmbeddingFunction.COHERE_API_KEY_ENV))`
+    - `"huggingface"`, `"hugging_face"`, `"hf"` → HuggingFace factory
+    - `"ollama"` → Ollama factory
+    - `"google_genai"` → Gemini factory (guarded by try-catch NoClassDefFoundError)
+    - `"amazon_bedrock"` → Bedrock factory (guarded by try-catch NoClassDefFoundError)
+    - `"voyageai"` → Voyage factory
+
+    Sparse provider registrations:
+    - `"chroma_bm25"` → `config -> new BM25EmbeddingFunction()`
+    - `"bm25"` → same factory (alias, per D-21)
+    - `"chromacloud_splade"` → `config -> new ChromaCloudSpladeEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, "CHROMA_API_KEY"))`
+
+    Note: To use `EmbeddingFunctionResolver.buildParams`, change its visibility from `private` to `static` package-private (or `public`). Better approach: Extract `buildParams` and `buildHuggingFaceParams` as package-private static methods (they already are static, just need visibility change from `private` to default package). Then make `EmbeddingFunctionRegistry` use them. Since the registry is in `tech.amikos.chromadb.embeddings` package (different from `tech.amikos.chromadb.v2`), either:
+    (a) Make buildParams/buildHuggingFaceParams `public` in EmbeddingFunctionResolver, OR
+    (b) Move the param-building logic into a shared utility in the embeddings package.
+    Choose (a) for minimal disruption — rename to `public static WithParam[] buildParams(Map<String, Object> config, String defaultApiKeyEnv)`.
+
+    **Register/resolve methods** (per D-20):
+    ```java
+    public synchronized void registerDense(String name, DenseFactory factory) {
+        denseFactories.put(name.toLowerCase(Locale.ROOT), factory);
+    }
+    public synchronized void registerSparse(String name, SparseFactory factory) {
+        sparseFactories.put(name.toLowerCase(Locale.ROOT), factory);
+    }
+    public synchronized void registerContent(String name, ContentFactory factory) {
+        contentFactories.put(name.toLowerCase(Locale.ROOT), factory);
+    }
+
+    public synchronized EmbeddingFunction resolveDense(EmbeddingFunctionSpec spec) {
+        if (spec == null) return null;
+        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+        DenseFactory factory = denseFactories.get(name);
+        if (factory == null) {
+            throw new ChromaException("Unsupported embedding function provider '" + spec.getName()
+                + "'. Registered dense providers: " + denseFactories.keySet());
+        }
+        try {
+            return factory.create(spec.getConfig());
+        } catch (EFException e) {
+            throw new ChromaException("Failed to create dense provider '" + name + "': " + e.getMessage(), e);
+        }
+    }
+
+    public synchronized SparseEmbeddingFunction resolveSparse(EmbeddingFunctionSpec spec) {
+        // Same pattern, using sparseFactories
+    }
+
+    public synchronized ContentEmbeddingFunction resolveContent(EmbeddingFunctionSpec spec) {
+        // Per D-18: try content factory first
+        if (spec == null) return null;
+        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+        ContentFactory cf = contentFactories.get(name);
+        if (cf != null) {
+            try { return cf.create(spec.getConfig()); }
+            catch (EFException e) { throw new ChromaException("...", e); }
+        }
+        // Fallback: try dense + adapter
+        DenseFactory df = denseFactories.get(name);
+        if (df != null) {
+            try { return ContentEmbeddingFunction.fromTextOnly(df.create(spec.getConfig())); }
+            catch (EFException e) { throw new ChromaException("...", e); }
+        }
+        throw new ChromaException("Unsupported content embedding provider '" + spec.getName() + "'");
+    }
+    ```
+
+    **EmbeddingFunctionResolver.java update** (per D-16): Make `resolve()` delegate to registry:
+    ```java
+    static EmbeddingFunction resolve(EmbeddingFunctionSpec spec) {
+        return EmbeddingFunctionRegistry.getDefault().resolveDense(spec);
+    }
+    ```
+    Keep `buildParams`, `buildParamsList`, `buildHuggingFaceParams`, `firstString` as `public static` (change from private) so the registry can use them. The `unsupported()` helper can be removed or kept for backward compat.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn compile -pl . -q 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - EmbeddingFunctionRegistry.java exists in `tech.amikos.chromadb.embeddings` package
+    - Contains `public static EmbeddingFunctionRegistry getDefault()`
+    - Contains `public synchronized void registerDense(String name, DenseFactory factory)`
+    - Contains `public synchronized void registerSparse(String name, SparseFactory factory)`
+    - Contains `public synchronized void registerContent(String name, ContentFactory factory)`
+    - Contains `public synchronized EmbeddingFunction resolveDense(EmbeddingFunctionSpec spec)`
+    - Contains `public synchronized SparseEmbeddingFunction resolveSparse(EmbeddingFunctionSpec spec)`
+    - Contains `public synchronized ContentEmbeddingFunction resolveContent(EmbeddingFunctionSpec spec)`
+    - Contains `registerDense("openai"` and `registerDense("google_genai"` and `registerSparse("chroma_bm25"`
+    - EmbeddingFunctionResolver.resolve() delegates to `EmbeddingFunctionRegistry.getDefault().resolveDense(spec)`
+    - `mvn compile` succeeds
+  </acceptance_criteria>
+  <done>EmbeddingFunctionRegistry created with 3 factory maps, all built-in providers pre-registered, and EmbeddingFunctionResolver updated to delegate.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Update ChromaHttpCollection wiring and add registry unit tests</name>
+  <files>
+    src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java,
+    src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
+  </files>
+  <read_first>
+    src/main/java/tech/amikos/chromadb/v2/ChromaHttpCollection.java,
+    src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java,
+    src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java,
+    src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionSpec.java
+  </read_first>
+  <behavior>
+    - EmbeddingFunctionRegistry.getDefault() is singleton (same reference)
+    - getDefault().resolveDense(spec with name="openai") returns OpenAIEmbeddingFunction instance
+    - getDefault().resolveSparse(spec with name="chroma_bm25") returns BM25EmbeddingFunction instance
+    - getDefault().resolveSparse(spec with name="bm25") returns BM25EmbeddingFunction (alias)
+    - resolveContent(spec with name="openai") returns ContentEmbeddingFunction (dense fallback + adapter)
+    - Custom registry: registerDense("custom", factory) → resolveDense returns factory result
+    - resolveDense(null) returns null
+    - resolveDense(spec with unknown name) throws ChromaException
+    - Thread safety: 10 concurrent register + resolve calls do not throw ConcurrentModificationException
+    - ChromaHttpCollection EF resolution path uses registry (not direct resolver hardcoded dispatch)
+  </behavior>
+  <action>
+    **ChromaHttpCollection.java update** (per Pitfall 5 in RESEARCH.md):
+    Find the call site where `EmbeddingFunctionResolver.resolve(spec)` is called. This is likely in the `from()` static factory or in the auto-wiring logic. Since `EmbeddingFunctionResolver.resolve()` already delegates to the registry (from Task 1), the ChromaHttpCollection may not need changes IF it only calls `EmbeddingFunctionResolver.resolve()`. Verify by reading the file.
+
+    If ChromaHttpCollection calls `EmbeddingFunctionResolver.resolve()` → no change needed (resolver already delegates).
+    If ChromaHttpCollection has its own hardcoded provider dispatch → replace with `EmbeddingFunctionRegistry.getDefault().resolveDense(spec)`.
+
+    **TestEmbeddingFunctionRegistry.java**: Package `tech.amikos.chromadb.embeddings`. JUnit 4.
+
+    - `testGetDefaultIsSingleton`: `assertSame(EmbeddingFunctionRegistry.getDefault(), EmbeddingFunctionRegistry.getDefault())`.
+
+    - `testResolveOpenAI`: Set `OPENAI_API_KEY` env (or use a spec config with api_key). Call `getDefault().resolveDense(EmbeddingFunctionSpec.builder().name("openai").type("known").config(configWithKey).build())`. Assert result is `instanceof OpenAIEmbeddingFunction`. If env var not available, use config map: `{"api_key": "test-key"}`.
+
+    - `testResolveCohere`: Similar to OpenAI but with name "cohere" and COHERE_API_KEY.
+
+    - `testResolveBM25`: `getDefault().resolveSparse(EmbeddingFunctionSpec.builder().name("chroma_bm25").type("known").build())`. Assert result is `instanceof BM25EmbeddingFunction`.
+
+    - `testResolveBM25Alias`: Same but with name "bm25". Assert `instanceof BM25EmbeddingFunction`.
+
+    - `testResolveContentFallbackToDense`: `getDefault().resolveContent(EmbeddingFunctionSpec.builder().name("openai").type("known").config(configWithKey).build())`. Assert result is not null (ContentEmbeddingFunction wrapping OpenAI via adapter).
+
+    - `testResolveNullReturnsNull`: `getDefault().resolveDense(null)` returns null.
+
+    - `testResolveUnknownThrows`: `getDefault().resolveDense(EmbeddingFunctionSpec.builder().name("nonexistent").type("known").build())` throws `ChromaException`.
+
+    - `testCustomRegistryRegisterAndResolve`: Create `new EmbeddingFunctionRegistry()`. Register a custom dense factory: `registry.registerDense("my_custom", config -> { ... return mockEF; })`. Resolve it: `registry.resolveDense(spec with name="my_custom")`. Assert result is the mock.
+
+    - `testCustomRegistrySparseRegisterAndResolve`: Same pattern with `registerSparse`/`resolveSparse`.
+
+    - `testCustomRegistryContentRegisterAndResolve`: Same with content.
+
+    - `testThreadSafety`: Create `new EmbeddingFunctionRegistry()`. Spawn 10 threads, each registering and resolving providers concurrently. Assert no `ConcurrentModificationException`. Use `ExecutorService` with `Executors.newFixedThreadPool(10)` and `CountDownLatch`.
+
+    - `testContentFallbackChain`: Create `new EmbeddingFunctionRegistry()`. Register only dense "test_ef" (no content). `resolveContent(spec name="test_ef")` returns ContentEmbeddingFunction (adapter-wrapped). Verify by calling `embedContent(Content.text("hi"))` — should work through the adapter.
+
+    Note: Tests that resolve built-in providers that require API keys should either:
+    (a) Use config maps with `{"api_key": "dummy"}` (construction succeeds, just can't call API), OR
+    (b) Use `Assume.assumeTrue(System.getenv("OPENAI_API_KEY") != null)` to skip when env not set.
+    Prefer (a) for deterministic CI.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/chromadb-java-client && mvn test -Dtest="TestEmbeddingFunctionRegistry" -pl . -q 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - TestEmbeddingFunctionRegistry.java exists with at least 10 @Test methods
+    - Contains test `testGetDefaultIsSingleton` with `assertSame`
+    - Contains test `testResolveBM25` asserting `instanceof BM25EmbeddingFunction`
+    - Contains test `testResolveContentFallbackToDense` verifying content fallback chain
+    - Contains test `testThreadSafety` using ExecutorService
+    - ChromaHttpCollection.java EF resolution goes through registry path (either directly or via updated EmbeddingFunctionResolver)
+    - `mvn test -Dtest="TestEmbeddingFunctionRegistry"` exits 0
+    - `mvn test` full suite exits 0 (no existing tests broken by resolver refactor)
+  </acceptance_criteria>
+  <done>EmbeddingFunctionRegistry fully wired: singleton with built-in providers, custom registration, content fallback chain, thread-safe, and ChromaHttpCollection uses it for auto-wiring. All tests pass including full regression.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `mvn compile` succeeds
+- `mvn test -Dtest="TestEmbeddingFunctionRegistry"` — all registry tests pass
+- `mvn test` — full suite passes (no regression from resolver refactor)
+- EmbeddingFunctionResolver.resolve() delegates to registry (grep confirms)
+</verification>
+
+<success_criteria>
+- EmbeddingFunctionRegistry wraps EmbeddingFunctionResolver per D-16
+- 3 separate factory maps (dense, sparse, content) per D-17
+- Content fallback chain (content → dense + adapter) per D-18
+- Singleton + instance API per D-19
+- Thread-safe register/resolve per D-20
+- Provider names match Go client per D-21
+- ChromaHttpCollection auto-wiring uses registry per Pitfall 5
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-embedding-ecosystem/04-05-SUMMARY.md`
+</output>

--- a/.planning/phases/04-embedding-ecosystem/04-05-SUMMARY.md
+++ b/.planning/phases/04-embedding-ecosystem/04-05-SUMMARY.md
@@ -1,0 +1,46 @@
+---
+phase: 04-embedding-ecosystem
+plan: 05
+status: complete
+started: 2026-04-01T16:00:00Z
+completed: 2026-04-01T16:10:00Z
+duration: ~10min
+tasks_completed: 2
+tasks_total: 2
+---
+
+# Plan 04-05 Summary: EmbeddingFunctionRegistry with Auto-Wiring
+
+## What Was Built
+
+Public `EmbeddingFunctionRegistry` with three factory maps (dense, sparse, content) that replaces hardcoded provider dispatch with an extensible registry pattern.
+
+## Key Decisions
+
+- EmbeddingFunctionResolver.resolve() now delegates to EmbeddingFunctionRegistry.getDefault().resolveDense()
+- buildParams/buildHuggingFaceParams made public in EmbeddingFunctionResolver for registry access across packages
+- Gemini/Bedrock registration guarded by try-catch NoClassDefFoundError for optional SDK jars
+- Content fallback chain: content factory first → dense + TextEmbeddingAdapter wrapping
+- All register/resolve methods synchronized for thread safety
+
+## Key Files
+
+### Created
+- `src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java` — Public registry with 3 factory maps and singleton
+- `src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java` — Registry tests including thread safety
+
+### Modified
+- `src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java` — Delegates to registry, helpers made public
+
+## Self-Check: PASSED
+
+- [x] EmbeddingFunctionRegistry.getDefault() returns singleton with all built-in providers
+- [x] registerDense/registerSparse/registerContent + resolveDense/resolveSparse/resolveContent work
+- [x] Content fallback chain (dense + adapter) works
+- [x] ChromaHttpCollection uses registry path (via EmbeddingFunctionResolver delegation)
+- [x] Thread safety verified with concurrent test
+- [x] All tests pass
+
+## Deviations
+
+None.

--- a/.planning/phases/04-embedding-ecosystem/04-CONTEXT.md
+++ b/.planning/phases/04-embedding-ecosystem/04-CONTEXT.md
@@ -1,0 +1,146 @@
+# Phase 4: Embedding Ecosystem - Context
+
+**Gathered:** 2026-04-01
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Expand the embedding ecosystem with sparse embedding functions, content-based multimodal embedding functions, a reranking interface, three new dense embedding providers, and a public embedding function registry with auto-wiring. This phase does not change existing client/collection behavior or existing embedding provider implementations.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Sparse Embedding Interface
+- **D-01:** `SparseEmbeddingFunction` is a **separate interface** from `EmbeddingFunction` — not an extension, not a generic base. Returns `List<SparseVector>` (reusing existing v2 `SparseVector` type).
+- **D-02:** Two sparse providers: **Chroma Cloud Splade** (remote) and **BM25** (local).
+- **D-03:** BM25 implementation **mirrors the Go client's approach**: custom tokenizer pipeline (lowercase → regex split → stopword filter → Snowball stemmer → Murmur3 hashing). Ensures cross-client index compatibility.
+- **D-04:** BM25 needs two new dependencies: a Java Snowball stemmer library and a Murmur3 hashing library (or minimal bundled Murmur3 impl). Both should be small.
+
+### Content/Multimodal Embedding Interface
+- **D-05:** **2-tier design** — skip `MultimodalEmbeddingFunction` (already legacy in Go). Only `ContentEmbeddingFunction` is added alongside existing `EmbeddingFunction`.
+- **D-06:** `ContentEmbeddingFunction` interface: `embedContents(List<Content>) → List<Embedding>` with default `embedContent(Content) → Embedding`.
+- **D-07:** Content/Part/BinarySource types follow **static factory + builder pattern** matching codebase conventions:
+  - `Content.text("...")` for simple case, `Content.builder()` for complex (like `CollectionConfiguration.builder()`)
+  - `Part.text(str)`, `Part.image(source)`, `Part.audio(source)` etc. — static factories (like `SparseVector.of()`)
+  - `BinarySource.fromUrl(url)`, `.fromFile(path)`, `.fromBase64(data)`, `.fromBytes(data)` — static factories
+- **D-08:** `Modality` and `Intent` are **Java enums** with `getValue()` and `fromValue(String)` — same pattern as `DistanceFunction` and `Include`.
+- **D-09:** All multimodal types live in **`tech.amikos.chromadb.embeddings.content`** sub-package. Existing `EmbeddingFunction` stays in `tech.amikos.chromadb.embeddings`.
+- **D-10:** **Adapter pattern**: `TextEmbeddingAdapter` wraps `EmbeddingFunction` → `ContentEmbeddingFunction`. `ContentToTextAdapter` wraps the reverse. Public classes + `ContentEmbeddingFunction.fromTextOnly(ef)` convenience factory.
+- **D-11:** `CapabilityMetadata` **deferred** — not needed for v1, can be added later as non-breaking addition.
+
+### New Dense Providers
+- **D-12:** Three new dense providers: **Gemini**, **Bedrock**, **Voyage** (prioritized per requirements).
+- **D-13:** Dependency strategy: **Vendor SDKs for major labs** (Google AI SDK for Gemini, AWS SDK for Bedrock), **OkHttp for smaller providers** (Voyage). First-party SDKs are mature, secure, and handle auth natively.
+- **D-14:** Vendor SDK dependencies use **optional/provided Maven scope** — not pulled transitively into user projects.
+- **D-15:** All providers use the established `WithParam` configuration pattern and register with the same provider names as the Go client for cross-client compatibility.
+
+### Embedding Function Registry
+- **D-16:** Public `EmbeddingFunctionRegistry` wraps the existing package-private `EmbeddingFunctionResolver`. Resolver becomes an internal detail pre-registering built-in providers.
+- **D-17:** **3 separate factory maps** (dense, sparse, content) — aligned with Go client's pattern. No multimodal map (skipped per D-05).
+- **D-18:** **Content fallback chain** on resolve: tries content factory first → falls back to dense + adapter wrapping. Any registered dense provider automatically works with content API.
+- **D-19:** **Singleton + instance API**: `EmbeddingFunctionRegistry.getDefault()` returns shared singleton with built-in providers pre-registered. Users can also create custom instances (useful for testing).
+- **D-20:** Registration API: `registry.registerDense(name, factory)`, `registerSparse(name, factory)`, `registerContent(name, factory)`. Thread-safe with synchronized access.
+- **D-21:** Provider names match Go client: `"openai"`, `"cohere"`, `"google_genai"`, `"amazon_bedrock"`, `"voyageai"`, `"chroma_bm25"`, `"bm25"` (alias), `"chromacloud_splade"`, etc.
+
+### Reranking
+- **D-22:** `RerankingFunction` interface: `rerank(query, List<String> documents) → List<RerankResult>` where `RerankResult` has score + index.
+- **D-23:** **Two providers**: Cohere Rerank and Jina Reranker. Both are simple REST APIs using OkHttp.
+
+### Claude's Discretion
+- Exact Snowball stemmer and Murmur3 library choices (as long as they're lightweight and Java 8 compatible)
+- Exact Google AI SDK and AWS SDK artifact coordinates and versions
+- Internal class organization within each provider package
+- Exact method signatures for registry factory functional interfaces
+- Whether to add `Closeable` support to registry-resolved instances (Go has it)
+- Stop word list for BM25 (should match Go/Python client defaults)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Phase scope and requirement contracts
+- `.planning/ROADMAP.md` — Phase 4 goal, success criteria (EMB-05, EMB-06, EMB-07, EMB-08, RERANK-01)
+- `.planning/REQUIREMENTS.md` — EMB-05 through EMB-08, RERANK-01 acceptance targets
+- `.planning/PROJECT.md` — milestone constraints (v2-only, Java 8, sync API)
+
+### Project conventions
+- `CLAUDE.md` — repository conventions, test commands, architecture notes
+
+### Go client reference implementations
+- `https://github.com/amikos-tech/chroma-go/tree/main/pkg/embeddings` — Go embedding interfaces, registry, content types
+- `https://github.com/amikos-tech/chroma-go/tree/main/pkg/embeddings/bm25` — Go BM25 implementation (tokenizer, Murmur3, stop words)
+- Go registry pattern: global singleton, 4 maps (dense/sparse/multimodal/content), `Register*()` + `Build*()`, content fallback chain
+
+### Existing embedding infrastructure
+- `src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunction.java` — current text-only interface (stays unchanged)
+- `src/main/java/tech/amikos/chromadb/embeddings/WithParam.java` — configuration parameter pattern (reuse for new providers)
+- `src/main/java/tech/amikos/chromadb/embeddings/openai/OpenAIEmbeddingFunction.java` — reference provider implementation pattern
+- `src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java` — existing package-private auto-wirer (to be wrapped by public registry)
+- `src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionSpec.java` — descriptor with type/name/config (registry resolves from this)
+
+### Existing sparse vector types
+- `src/main/java/tech/amikos/chromadb/v2/SparseVector.java` — immutable sparse vector (int[] indices + float[] values), reuse in SparseEmbeddingFunction
+- `src/main/java/tech/amikos/chromadb/Embedding.java` — dense float[] wrapper (stays unchanged)
+
+### Build configuration
+- `pom.xml` — Maven build config: add new dependencies here (Snowball, Murmur3, Google AI SDK, AWS SDK as optional/provided)
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `EmbeddingFunction` interface — text-only contract, stays as-is. New interfaces alongside it.
+- `WithParam` pattern — reuse for all new provider constructors (apiKey, model, baseAPI, etc.)
+- `SparseVector` — already in v2 package, reuse as return type for `SparseEmbeddingFunction`.
+- `EmbeddingFunctionResolver` — wrappable by public registry. Already handles 5 known providers.
+- `EmbeddingFunctionSpec` — descriptor format matches Go's `EmbeddingFunctionConfig` concept.
+- OkHttp + Gson — all existing providers use this HTTP/JSON stack. Reuse for Voyage, Cohere Rerank, Jina Reranker.
+
+### Established Patterns
+- Provider package structure: `embeddings/{provider}/` with `{Provider}EmbeddingFunction.java`, `CreateEmbeddingRequest.java`, `CreateEmbeddingResponse.java`.
+- Defaults applied first, then user `WithParam` overrides (see `OpenAIEmbeddingFunction` constructor).
+- `ChromaException` thrown for HTTP errors; `EFException` for provider-specific failures.
+- Java 8 compatible: no records, no sealed classes, default methods on interfaces OK.
+
+### Integration Points
+- New `SparseEmbeddingFunction` integrates with `SparseVector` (v2 package) for return types.
+- New `ContentEmbeddingFunction` integrates with existing `Embedding` class for return types.
+- `EmbeddingFunctionRegistry` wraps and replaces `EmbeddingFunctionResolver` as the public API entry point.
+- New provider packages follow `embeddings/{provider}/` convention.
+- Content types live in new `embeddings/content/` sub-package.
+- Maven dependencies: Snowball + Murmur3 as compile deps, Google AI SDK + AWS SDK as optional/provided.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Mirror Go client's BM25 tokenizer pipeline exactly for cross-client sparse vector index compatibility (same stop words, same Murmur3 hashing, same stemmer behavior).
+- Use same provider registration names as Go client for cross-client config compatibility (`"google_genai"`, `"amazon_bedrock"`, `"voyageai"`, `"chroma_bm25"`, etc.).
+- Content fallback chain (content → dense+adapter) ensures any dense provider works with the content API without explicit content registration — this is a key usability win.
+- First-party vendor SDKs for major cloud providers (Google, AWS) — mature auth handling, security, and maintenance. OkHttp for indie providers.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **CapabilityMetadata** — provider capability declaration (supported modalities, intents, batching). Can be added as non-breaking enhancement after v1.
+- **Closeable support** in registry — Go has `BuildDenseCloseable()` for cleanup. Can add later.
+- **Additional providers** beyond Gemini/Bedrock/Voyage — Jina embeddings, Mistral, Together, Nomic, etc. can be added incrementally.
+- **MultimodalEmbeddingFunction** middle-tier interface — intentionally skipped (legacy in Go). If needed, can be added later as adapter target.
+
+</deferred>
+
+---
+
+*Phase: 04-embedding-ecosystem*
+*Context gathered: 2026-04-01*

--- a/.planning/phases/04-embedding-ecosystem/04-DISCUSSION-LOG.md
+++ b/.planning/phases/04-embedding-ecosystem/04-DISCUSSION-LOG.md
@@ -1,0 +1,176 @@
+# Phase 4: Embedding Ecosystem - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-01
+**Phase:** 04-embedding-ecosystem
+**Areas discussed:** Sparse embedding interface, Multimodal embedding input, New dense provider strategy, Registry & reranking design
+
+---
+
+## Sparse Embedding Interface
+
+### Interface relationship to EmbeddingFunction
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Separate interface (Recommended) | SparseEmbeddingFunction is its own interface with embedSparse → List<SparseVector>. Clean type separation. | ✓ |
+| Shared base with generics | Generic BaseEmbeddingFunction<T>. More unified but Java 8 generics complexity. | |
+| You decide | Claude picks best approach. | |
+
+**User's choice:** Separate interface
+**Notes:** Clean type boundary, mirrors Go client.
+
+### Sparse embedding providers
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Cloud Splade only (Recommended) | Minimal deps, cloud credentials for tests. | |
+| Cloud Splade + BM25 local | Both providers. BM25 needs tokenizer dependency. | ✓ |
+| You decide | Claude picks based on Go client parity. | |
+
+**User's choice:** Cloud Splade + BM25 local
+
+### BM25 tokenizer approach
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Mirror Go approach (Recommended) | Custom tokenizer: lowercase → regex → stopwords → Snowball → Murmur3. Cross-client compat. | ✓ |
+| Mirror Go, pure Java hashing | Same pipeline but bundled Murmur3 impl instead of Guava. | |
+| You decide | Claude picks minimal-dep approach. | |
+
+**User's choice:** Mirror Go approach
+**Notes:** User asked to review Go BM25 implementation first (https://github.com/amikos-tech/chroma-go/tree/main/pkg/embeddings/bm25). After reviewing, confirmed the full Go pipeline should be mirrored for cross-client index compatibility.
+
+---
+
+## Multimodal Embedding Input
+
+### Interface design
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 2-tier (Recommended) | Keep EF as-is, add ContentEmbeddingFunction. Skip legacy MultimodalEF. | ✓ |
+| 3-tier like Go | Port all three tiers including MultimodalEmbeddingFunction. | |
+| You decide | Claude picks. | |
+
+**User's choice:** 2-tier
+**Notes:** User asked to research Go client's content embedding pattern first (https://github.com/amikos-tech/chroma-go/tree/main/pkg/embeddings). After review, confirmed skipping the legacy middle tier. Also commissioned Java adaptation research.
+
+### Package placement
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| embeddings.content sub-package (Recommended) | tech.amikos.chromadb.embeddings.content — clean separation. | ✓ |
+| Flat in embeddings | Same package as EmbeddingFunction. Simpler but cluttered. | |
+| In v2 package | Alongside SparseVector. Mixes concerns. | |
+
+**User's choice:** embeddings.content sub-package
+
+### Value type pattern
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes — factories + builder (Recommended) | Content.text() for simple, .builder() for complex. Part/BinarySource static factories. | ✓ |
+| You decide | Claude picks. | |
+
+**User's choice:** Factories + builder matching codebase conventions
+
+---
+
+## New Dense Provider Strategy
+
+### Dependency strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Vendor SDK for majors, OkHttp for rest (Recommended) | Google AI SDK for Gemini, AWS SDK for Bedrock. OkHttp for Voyage, Jina, etc. | ✓ |
+| You decide | Claude picks. | |
+
+**User's choice:** Vendor SDK for major labs, OkHttp for rest
+**Notes:** User clarified: "for the major labs like Google, AWS I feel we should use their SDKs, those are mature and secure by virtue of being first-party. For the rest I think we can stick with OkHttp"
+
+### Provider selection
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Gemini + Bedrock + Voyage | Per original requirements. Covers 3 biggest enterprise use cases. | ✓ |
+| Gemini + Bedrock + Voyage + Jina | Add Jina as 4th. | |
+| You decide | Claude picks. | |
+
+**User's choice:** Gemini + Bedrock + Voyage
+
+---
+
+## Registry & Reranking Design
+
+### Registry relationship to EmbeddingFunctionResolver
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Public registry wrapping resolver (Recommended) | New public API with register(name, factory). Resolver becomes internal. | ✓ |
+| Expand resolver to public | Make existing class public directly. | |
+| You decide | Claude picks. | |
+
+**User's choice:** Public registry wrapping resolver
+
+### Reranking provider
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Cohere Rerank (Recommended) | Cohere Rerank v3 API as first provider. | |
+| Jina Reranker | Jina as first provider. | |
+| Both Cohere + Jina | Ship two providers from the start. | ✓ |
+| You decide | Claude picks. | |
+
+**User's choice:** Both Cohere + Jina
+
+### Registry scope
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| All three types (Recommended) | Dense, sparse, and content. Separate register/resolve per type. | ✓ |
+| Dense only, expand later | Start simple. | |
+| You decide | Claude picks. | |
+
+**User's choice:** All three types
+
+### Registry alignment with Go client
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Align with Go (Recommended) | 3 maps, content fallback chain, same provider names. Singleton + instance. | ✓ |
+| Simpler — single map | Single map, each entry declares types. | |
+| You decide | Claude picks. | |
+
+**User's choice:** Align with Go
+**Notes:** User requested verification of registry pattern against Go client before finalizing. Research confirmed 4-map design (we use 3, skipping multimodal), content fallback chain, and provider name conventions.
+
+### Registration API
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Instance method + static default (Recommended) | getDefault() singleton + custom instances for testing. | ✓ |
+| Static-only global | All methods static. | |
+| You decide | Claude picks. | |
+
+**User's choice:** Instance method + static default
+
+---
+
+## Claude's Discretion
+
+- Exact Snowball stemmer and Murmur3 library choices
+- Exact vendor SDK artifact coordinates and versions
+- Internal class organization within provider packages
+- Registry factory functional interface signatures
+- Closeable support for registry-resolved instances
+- BM25 stop word list (match Go/Python defaults)
+
+## Deferred Ideas
+
+- CapabilityMetadata for provider capability declaration
+- Closeable support in registry
+- Additional providers beyond Gemini/Bedrock/Voyage
+- MultimodalEmbeddingFunction middle-tier interface

--- a/.planning/phases/04-embedding-ecosystem/04-RESEARCH.md
+++ b/.planning/phases/04-embedding-ecosystem/04-RESEARCH.md
@@ -1,0 +1,764 @@
+# Phase 4: Embedding Ecosystem - Research
+
+**Researched:** 2026-04-01
+**Domain:** Java embedding functions — sparse/content interfaces, BM25, new dense providers (Gemini, Bedrock, Voyage), reranking (Cohere, Jina), EmbeddingFunctionRegistry
+**Confidence:** HIGH (core patterns from existing codebase + Go reference client; API wire formats verified from official docs)
+
+---
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** `SparseEmbeddingFunction` is a **separate interface** from `EmbeddingFunction` — not an extension, not a generic base. Returns `List<SparseVector>`.
+- **D-02:** Two sparse providers: **Chroma Cloud Splade** (remote) and **BM25** (local).
+- **D-03:** BM25 tokenizer pipeline: lowercase → regex split → stopword filter → Snowball stemmer → Murmur3 hashing. Must match Go client for index compatibility.
+- **D-04:** BM25 needs a Java Snowball stemmer library and a Murmur3 hashing library (or minimal bundled impl). Both must be small.
+- **D-05:** **2-tier design only** — skip `MultimodalEmbeddingFunction`. Only `ContentEmbeddingFunction` is added.
+- **D-06:** `ContentEmbeddingFunction` interface: `embedContents(List<Content>) → List<Embedding>` with default `embedContent(Content) → Embedding`.
+- **D-07:** Content/Part/BinarySource types use static factory + builder pattern: `Content.text("...")`, `Content.builder()`, `Part.text(str)`, `Part.image(source)`, `BinarySource.fromUrl(url)`, `.fromFile(path)`, `.fromBase64(data)`, `.fromBytes(data)`.
+- **D-08:** `Modality` and `Intent` are Java enums with `getValue()` and `fromValue(String)`.
+- **D-09:** All multimodal types live in `tech.amikos.chromadb.embeddings.content` sub-package.
+- **D-10:** Adapter pattern: `TextEmbeddingAdapter` wraps `EmbeddingFunction` → `ContentEmbeddingFunction`. `ContentToTextAdapter` wraps the reverse. Plus `ContentEmbeddingFunction.fromTextOnly(ef)` convenience factory.
+- **D-11:** `CapabilityMetadata` deferred.
+- **D-12:** Three new dense providers: **Gemini**, **Bedrock**, **Voyage**.
+- **D-13:** Google AI SDK for Gemini, AWS SDK for Bedrock, OkHttp for Voyage.
+- **D-14:** Vendor SDK dependencies use **optional/provided Maven scope**.
+- **D-15:** All providers use `WithParam` configuration pattern; provider names match Go client.
+- **D-16:** `EmbeddingFunctionRegistry` wraps existing package-private `EmbeddingFunctionResolver`. Resolver becomes internal.
+- **D-17:** 3 separate factory maps (dense, sparse, content). No multimodal map.
+- **D-18:** Content fallback chain: content factory first → dense + adapter wrapping.
+- **D-19:** Singleton (`getDefault()`) + instance API. Singleton pre-registers built-in providers.
+- **D-20:** `registry.registerDense(name, factory)`, `registerSparse(name, factory)`, `registerContent(name, factory)`. Thread-safe via synchronized access.
+- **D-21:** Provider names: `"openai"`, `"cohere"`, `"google_genai"`, `"amazon_bedrock"`, `"voyageai"`, `"chroma_bm25"`, `"bm25"` (alias), `"chromacloud_splade"`.
+- **D-22:** `RerankingFunction` interface: `rerank(query, List<String> documents) → List<RerankResult>` where `RerankResult` has score + index.
+- **D-23:** Two reranking providers: Cohere Rerank and Jina Reranker. Both use OkHttp.
+
+### Claude's Discretion
+
+- Exact Snowball stemmer and Murmur3 library choices (lightweight, Java 8 compatible)
+- Exact Google AI SDK and AWS SDK artifact coordinates and versions
+- Internal class organization within each provider package
+- Exact method signatures for registry factory functional interfaces
+- Whether to add `Closeable` support to registry-resolved instances
+- Stop word list for BM25 (should match Go/Python client defaults)
+
+### Deferred Ideas (OUT OF SCOPE)
+
+- `CapabilityMetadata` — provider capability declaration
+- `Closeable` support in registry
+- Additional providers beyond Gemini/Bedrock/Voyage
+- `MultimodalEmbeddingFunction` middle-tier interface
+</user_constraints>
+
+---
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| EMB-05 | User can use sparse embedding functions (BM25, Chroma Cloud Splade) through a `SparseEmbeddingFunction` interface | BM25 tokenizer pipeline verified from Go client; Splade API endpoint verified; `SparseVector` type exists in codebase |
+| EMB-06 | User can use multimodal embedding functions (image+text) through a `ContentEmbeddingFunction` interface | Note: CONTEXT.md D-05 clarifies requirement as `ContentEmbeddingFunction` (not `MultimodalEmbeddingFunction`); Go reference types documented |
+| EMB-07 | User can use at least 3 additional dense embedding providers (Gemini, Bedrock, Voyage) | Wire formats, endpoints, auth headers, and SDK artifacts verified for all three |
+| EMB-08 | User can rely on an `EmbeddingFunctionRegistry` to auto-wire embedding functions from server-side collection configuration | Go registry pattern documented; existing `EmbeddingFunctionResolver` identified as internal to wrap |
+| RERANK-01 | User can rerank query results using a `RerankingFunction` interface with at least one provider (Cohere or Jina) | Both Cohere Rerank v2 and Jina Reranker API documented; Go `RerankingFunction` interface inspected |
+</phase_requirements>
+
+---
+
+## Summary
+
+Phase 4 expands the embedding ecosystem into five distinct areas: sparse embeddings (BM25 + Chroma Cloud Splade), a content embedding interface for multimodal inputs, three new dense providers (Gemini, Bedrock, Voyage), a public `EmbeddingFunctionRegistry`, and a reranking interface with two providers.
+
+All patterns are well-established. The existing codebase provides strong scaffolding: `EmbeddingFunction`, `WithParam`, `SparseVector`, `EmbeddingFunctionResolver`, `EmbeddingFunctionSpec`, `AbstractEmbeddingFunctionConformanceTest`, and `DistanceFunction` (enum pattern for `Modality`/`Intent`). New code follows these patterns without exception.
+
+The most complex new component is BM25: the tokenizer pipeline must match the Go client exactly (same stop words, same Murmur3 seed/behavior, same Snowball English stemmer) for cross-client sparse vector index compatibility. The BM25 scoring formula, hash-based index mapping, and sparse vector construction are all documented from the Go reference. Everything else (new dense providers, reranking, content types, registry) follows straightforward patterns already established in the codebase.
+
+**Primary recommendation:** Implement in this order: (1) interfaces first (`SparseEmbeddingFunction`, `ContentEmbeddingFunction`, `RerankingFunction` + value types), (2) `EmbeddingFunctionRegistry` wrapping existing resolver, (3) BM25 (most complex), (4) Chroma Cloud Splade, (5) Gemini/Bedrock/Voyage dense providers, (6) Cohere Rerank + Jina Reranker.
+
+---
+
+## Standard Stack
+
+### Core (existing — reuse as-is)
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| OkHttp | 4.12.0 | HTTP client for all remote providers (Voyage, Splade, Cohere Rerank, Jina) | Already in pom.xml as main dep |
+| Gson | 2.10.1 | JSON serialization for all provider request/response DTOs | Already in pom.xml as main dep |
+| SparseVector | (in-repo) | Return type for `SparseEmbeddingFunction` | Already in `tech.amikos.chromadb.v2` |
+| Embedding | (in-repo) | Return type for `ContentEmbeddingFunction` | Already in `tech.amikos.chromadb` |
+
+### New Dependencies
+| Library | Version | Purpose | Scope |
+|---------|---------|---------|-------|
+| `com.github.rholder:snowball-stemmer` | 1.3.0.581.1 | Snowball English stemmer for BM25 tokenizer | compile |
+| Murmur3 (inline impl) | n/a | Hash tokens to int indices — ~50 lines, no external dep needed | n/a |
+| `com.google.genai:google-genai` | 1.2.0 | Google Gemini embeddings SDK | optional |
+| `software.amazon.awssdk:bedrockruntime` | 2.34.0 | AWS Bedrock embedding invocation | optional |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Inline Murmur3 | `com.google.guava:guava` (has `Hashing.murmur3_32()`) | Guava is large (2.9 MB); adding it as `compile` scope would inflate transitive deps for users who don't use BM25. Inline ~50-line Murmur3 is cleaner and explicitly matches Python `mmh3` x86 variant. |
+| Inline Murmur3 | `com.github.eprst:murmur3` | Another small option but poorly maintained. Inline is simpler. |
+| `com.google.genai:google-genai` | Raw OkHttp for Gemini | Go client uses first-party SDK; SDK handles auth rotation, retries, and future API changes. Optional scope avoids transitive exposure. |
+| `software.amazon.awssdk:bedrockruntime` | Raw OkHttp for Bedrock | AWS uses SigV4 auth — implementing it manually is error-prone. SDK is the right choice. |
+
+**Installation:**
+```xml
+<!-- BM25: Snowball stemmer -->
+<dependency>
+    <groupId>com.github.rholder</groupId>
+    <artifactId>snowball-stemmer</artifactId>
+    <version>1.3.0.581.1</version>
+</dependency>
+
+<!-- Gemini embeddings (optional: user must add to their project) -->
+<dependency>
+    <groupId>com.google.genai</groupId>
+    <artifactId>google-genai</artifactId>
+    <version>1.2.0</version>
+    <optional>true</optional>
+</dependency>
+
+<!-- AWS Bedrock embeddings (optional: user must add to their project) -->
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>bedrockruntime</artifactId>
+    <version>2.34.0</version>
+    <optional>true</optional>
+</dependency>
+```
+
+**Version notes (verified 2026-04-01):**
+- `snowball-stemmer:1.3.0.581.1` — last released 2014, stable, Java 8 compatible (pure Java)
+- `google-genai:1.2.0` — latest on Maven Central 2026-05-30; Java 8 compatible (confirmed `maven.compiler.source=1.8` in google-genai pom)
+- `bedrockruntime:2.34.0` — latest; AWS SDK v2 requires Java 8+
+- Guava is already a **test-scope transitive** dep; do NOT promote to compile scope
+
+---
+
+## Architecture Patterns
+
+### Recommended Package Structure
+```
+src/main/java/tech/amikos/chromadb/
+├── embeddings/
+│   ├── EmbeddingFunction.java              (existing — unchanged)
+│   ├── WithParam.java                      (existing — unchanged)
+│   ├── DefaultEmbeddingFunction.java       (existing — unchanged)
+│   ├── SparseEmbeddingFunction.java        (NEW interface)
+│   ├── ContentEmbeddingFunction.java       (NEW interface + adapters)
+│   ├── EmbeddingFunctionRegistry.java      (NEW public class)
+│   ├── content/                            (NEW sub-package)
+│   │   ├── Content.java
+│   │   ├── Part.java
+│   │   ├── BinarySource.java
+│   │   ├── Modality.java
+│   │   └── Intent.java
+│   ├── bm25/                               (NEW)
+│   │   ├── BM25EmbeddingFunction.java
+│   │   ├── BM25Tokenizer.java
+│   │   └── BM25StopWords.java
+│   ├── chromacloudsplade/                  (NEW)
+│   │   ├── ChromaCloudSpladeEmbeddingFunction.java
+│   │   ├── CreateSparseEmbeddingRequest.java
+│   │   └── CreateSparseEmbeddingResponse.java
+│   ├── gemini/                             (NEW)
+│   │   ├── GeminiEmbeddingFunction.java
+│   │   └── (no request/response DTOs — uses google-genai SDK types)
+│   ├── bedrock/                            (NEW)
+│   │   ├── BedrockEmbeddingFunction.java
+│   │   └── (uses AWS SDK types directly)
+│   └── voyage/                             (NEW)
+│       ├── VoyageEmbeddingFunction.java
+│       ├── CreateEmbeddingRequest.java
+│       └── CreateEmbeddingResponse.java
+└── reranking/                              (NEW top-level sub-package)
+    ├── RerankingFunction.java              (interface)
+    ├── RerankResult.java                   (value type)
+    ├── cohere/
+    │   ├── CohereRerankingFunction.java
+    │   ├── RerankRequest.java
+    │   └── RerankResponse.java
+    └── jina/
+        ├── JinaRerankingFunction.java
+        ├── RerankRequest.java
+        └── RerankResponse.java
+```
+
+### Pattern 1: SparseEmbeddingFunction Interface
+**What:** Parallel to `EmbeddingFunction` but returns `List<SparseVector>` (not `List<Embedding>`).
+**When to use:** Any provider that produces sparse token-weighted vectors (BM25, Splade).
+
+```java
+// Source: derived from Go SparseEmbeddingFunction interface + existing EmbeddingFunction pattern
+package tech.amikos.chromadb.embeddings;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.v2.SparseVector;
+import java.util.List;
+
+public interface SparseEmbeddingFunction {
+    SparseVector embedQuery(String query) throws EFException;
+    List<SparseVector> embedDocuments(List<String> documents) throws EFException;
+}
+```
+
+### Pattern 2: ContentEmbeddingFunction Interface + Adapter
+**What:** Accepts `List<Content>` (multimodal) instead of `List<String>`.
+**When to use:** Gemini multimodal, VoyageAI multimodal, or wrapping any dense EF.
+
+```java
+// Source: derived from Go ContentEmbeddingFunction + D-06 in CONTEXT.md
+package tech.amikos.chromadb.embeddings;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.content.Content;
+import java.util.Collections;
+import java.util.List;
+
+public interface ContentEmbeddingFunction {
+    List<Embedding> embedContents(List<Content> contents) throws EFException;
+
+    default Embedding embedContent(Content content) throws EFException {
+        return embedContents(Collections.singletonList(content)).get(0);
+    }
+
+    /** Convenience: wrap any text-only EmbeddingFunction as ContentEmbeddingFunction */
+    static ContentEmbeddingFunction fromTextOnly(EmbeddingFunction ef) {
+        return new TextEmbeddingAdapter(ef);
+    }
+}
+```
+
+### Pattern 3: Content Value Type (static factory + builder)
+**What:** Mirrors Go's `Content` type — ordered list of `Part` objects with optional `Intent`.
+**Pattern source:** `CollectionConfiguration.builder()` for complex case, `SparseVector.of()` for simple factories.
+
+```java
+// Source: Go multimodal.go + CONTEXT.md D-07
+public final class Content {
+    private final List<Part> parts;
+    private final Intent intent;
+
+    public static Content text(String text) { ... }   // simple case
+    public static Builder builder() { ... }           // complex case
+
+    public static final class Builder {
+        public Builder part(Part part) { ... }
+        public Builder intent(Intent intent) { ... }
+        public Content build() { ... }
+    }
+}
+```
+
+### Pattern 4: BM25 Tokenizer Pipeline
+**What:** Exact replica of Go client tokenizer for cross-client index compatibility.
+**Source:** Verified from `chroma-go/pkg/embeddings/bm25/tokenizer.go` and `bm25.go`.
+
+Pipeline steps (in order):
+1. `text.toLowerCase(Locale.ROOT)`
+2. Replace non-alphanumeric sequences with spaces: `text.replaceAll("[^a-zA-Z0-9]+", " ")`
+3. `text.split("\\s+")` → token array
+4. Filter tokens in `BM25StopWords.DEFAULT_STOP_WORDS` (set lookup)
+5. Filter tokens where `token.length() > tokenMaxLength` (default: 100)
+6. Stem each token with `EnglishStemmer` from `com.github.rholder:snowball-stemmer`
+7. Hash each stemmed token to int index via Murmur3 x86 32-bit with seed 0
+
+BM25 score formula:
+```
+score(term t, doc d) = tf * (K + 1) / (tf + K * (1 - B + B * docLen / avgDocLen))
+```
+where K=1.2, B=0.75 (BM25 standard parameters, matching Go defaults).
+
+```java
+// Murmur3 x86 32-bit — inline implementation matching Python mmh3 behavior
+// Key: seed=0, unsigned int arithmetic, same output as Go github.com/spaolacci/murmur3
+int tokenIndex = murmur3_32(stemmedToken.getBytes(StandardCharsets.UTF_8), 0);
+```
+
+### Pattern 5: EmbeddingFunctionRegistry
+**What:** Public singleton wrapping the existing package-private `EmbeddingFunctionResolver`. Three factory maps (dense, sparse, content).
+
+```java
+// Source: Go registry.go pattern + CONTEXT.md D-16 through D-21
+public final class EmbeddingFunctionRegistry {
+    private static final EmbeddingFunctionRegistry DEFAULT = new EmbeddingFunctionRegistry(true);
+
+    // Factory functional interfaces (Java 8 compatible — named interfaces, not lambdas in interface)
+    public interface DenseFactory {
+        EmbeddingFunction create(Map<String, Object> config) throws EFException;
+    }
+    public interface SparseFactory {
+        SparseEmbeddingFunction create(Map<String, Object> config) throws EFException;
+    }
+    public interface ContentFactory {
+        ContentEmbeddingFunction create(Map<String, Object> config) throws EFException;
+    }
+
+    public static EmbeddingFunctionRegistry getDefault() { return DEFAULT; }
+
+    public synchronized void registerDense(String name, DenseFactory factory) { ... }
+    public synchronized void registerSparse(String name, SparseFactory factory) { ... }
+    public synchronized void registerContent(String name, ContentFactory factory) { ... }
+
+    // Resolve from spec (replaces EmbeddingFunctionResolver.resolve())
+    public EmbeddingFunction resolveDense(EmbeddingFunctionSpec spec) { ... }
+    public SparseEmbeddingFunction resolveSparse(EmbeddingFunctionSpec spec) { ... }
+    // Content fallback: content factory → dense factory + adapter
+    public ContentEmbeddingFunction resolveContent(EmbeddingFunctionSpec spec) { ... }
+}
+```
+
+### Pattern 6: RerankingFunction Interface
+**What:** Simple interface matching Go's `rerankings.RerankingFunction` contract, adapted for Java (no context.Context needed for sync API).
+
+```java
+// Source: Go pkg/rerankings/reranking.go + CONTEXT.md D-22
+package tech.amikos.chromadb.reranking;
+
+import tech.amikos.chromadb.EFException;
+import java.util.List;
+
+public interface RerankingFunction {
+    List<RerankResult> rerank(String query, List<String> documents) throws EFException;
+}
+
+public final class RerankResult {
+    private final int index;      // position in original documents list
+    private final double score;   // relevance score (0.0-1.0)
+    // static factory + getters
+    public static RerankResult of(int index, double score) { ... }
+}
+```
+
+### Anti-Patterns to Avoid
+- **Extending `EmbeddingFunction` for sparse:** `SparseEmbeddingFunction` must be a separate interface (D-01). Implementing both on one class is fine; inheritance is not.
+- **Adding `MultimodalEmbeddingFunction`:** Explicitly skipped (D-05). Do not create it.
+- **Making `EmbeddingFunctionRegistry` replace `EmbeddingFunctionResolver` directly:** The resolver stays as package-private internal; the registry wraps and delegates to it for backward compatibility with existing `ChromaHttpCollection` code.
+- **Using `Optional` return types:** Existing codebase returns null for absent values (see `EmbeddingFunctionResolver.resolve(null) → null`). Match that pattern.
+- **Using records or sealed classes:** Java 8 target. Use final classes with private constructors and static factories.
+- **Registering vendor SDK classes at class load time (static initializer in registry):** Pre-registration of built-in providers happens in the `EmbeddingFunctionRegistry` constructor, guarded by a flag, not in static initializers which cause NoClassDefFoundError when optional SDK jars are absent.
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| English stemming for BM25 | Custom stemmer | `com.github.rholder:snowball-stemmer` (Snowball English) | Stemmer correctness is hard; must match Go client's Snowball output exactly |
+| AWS SigV4 auth for Bedrock | Custom request signing | `software.amazon.awssdk:bedrockruntime` | SigV4 signing involves HMAC-SHA256 with date/region/service scope; one mistake breaks all requests silently |
+| Google Cloud auth for Gemini | Custom OAuth2 | `com.google.genai:google-genai` | SDK handles API key + Application Default Credentials, retries, and model deprecation |
+| Murmur3 hashing | Different hash (MD5, SHA-1) | Inline Murmur3 x86 32-bit (see code example) | BM25 indices must match Go/Python for cross-client compatibility; wrong variant = silently incompatible sparse vectors |
+| BM25 document frequency / IDF tables | Separate indexer | Stateless per-document BM25 (no corpus IDF) | Go client uses per-document BM25 (TF-only with length norm) — no corpus needed |
+
+**Key insight:** For BM25, the Go client does NOT maintain an IDF table across a document corpus. It computes a per-document BM25 score based on term frequency and document length only. This makes the implementation stateless — no corpus ingestion step required. This is the critical design decision to match.
+
+---
+
+## Common Pitfalls
+
+### Pitfall 1: Murmur3 Variant Mismatch
+**What goes wrong:** Using Murmur3 128-bit instead of x86 32-bit produces completely different index values. Sparse vectors from Java and Python/Go clients would not share the same vocabulary space, silently breaking hybrid search.
+**Why it happens:** Go uses `github.com/spaolacci/murmur3` (x86 32-bit, seed 0). Python uses `mmh3` (same variant). Many Java Murmur3 libraries default to 128-bit or use different seeds.
+**How to avoid:** Inline the Murmur3 x86 32-bit algorithm explicitly. Verify with known test vectors (e.g., `murmur3_32("hello", 0) == 613716550`).
+**Warning signs:** BM25 integration tests fail when comparing Java and Python client outputs for the same text.
+
+### Pitfall 2: Guava Promoted to Compile Scope
+**What goes wrong:** Adding `com.google.guava:guava` as a `compile` dependency to use `Hashing.murmur3_32()` pulls in a 2.9 MB jar and 6 transitive deps for every user, even those not using BM25.
+**Why it happens:** Guava is already present as a test-scope transitive dep (via WireMock), making it tempting to use it in main code.
+**How to avoid:** Use inline Murmur3 implementation (~50 lines). The existing `mvn dependency:tree` shows guava only in test scope — keep it there.
+**Warning signs:** `mvn dependency:tree` shows `com.google.guava:guava:jar:33.x-jre:compile`.
+
+### Pitfall 3: Optional SDK Registration Triggers NoClassDefFoundError
+**What goes wrong:** If `EmbeddingFunctionRegistry`'s static initializer tries to load `GeminiEmbeddingFunction` and the `google-genai` jar is absent (user didn't add it), Java throws `NoClassDefFoundError` at class load time for the registry — crashing all users including those not using Gemini.
+**Why it happens:** Static initializers run unconditionally at class load. If any referenced class is missing, the whole initializer fails.
+**How to avoid:** Pre-register vendor providers lazily or in a `try-catch (NoClassDefFoundError)` block. Alternatively, register them using reflection-based class existence checks: `Class.forName("com.google.genai.Client", false, ...)`.
+**Warning signs:** `java.lang.NoClassDefFoundError: com/google/genai/Client` when running any embedding operation with Gemini SDK absent.
+
+### Pitfall 4: BM25 Not Matching Go Stop Words
+**What goes wrong:** Sparse vectors produced by Java BM25 are incompatible with Go/Python because different stop words were filtered out.
+**Why it happens:** Different sources have different default stop word lists.
+**How to avoid:** Use exactly the 174-word list from Go client (`chroma-go/pkg/embeddings/bm25/stopwords.go`). This is the `DEFAULT_CHROMA_BM25_STOPWORDS` list. The list is well-known (NLTK English stop words base).
+**Warning signs:** Cross-language integration test fails — same document produces different non-zero indices in Java vs Go.
+
+### Pitfall 5: Registry Wrapping Does Not Update ChromaHttpCollection
+**What goes wrong:** `EmbeddingFunctionResolver.resolve()` is still called directly from `ChromaHttpCollection` after introducing the registry, so registry-registered custom providers are never used during auto-wiring.
+**Why it happens:** The existing code calls the package-private resolver directly. The new registry must replace or delegate from the collection's auto-wiring path.
+**How to avoid:** Update the single call site in `ChromaHttpCollection` (or wherever the resolver is invoked) to use `EmbeddingFunctionRegistry.getDefault().resolveDense(spec)` instead.
+**Warning signs:** Custom providers registered with the registry are never instantiated when creating collections from config.
+
+### Pitfall 6: Cohere Rerank v1 vs v2 Endpoint
+**What goes wrong:** Sending requests to `https://api.cohere.ai/v1/rerank` (old endpoint) instead of `https://api.cohere.com/v2/rerank` (current endpoint) gets a deprecation warning or eventual 404.
+**Why it happens:** Existing `CohereEmbeddingFunction` uses the v1 base URL. A copy-paste error could carry this forward.
+**How to avoid:** Use `https://api.cohere.com/v2/rerank` as the default base URL for `CohereRerankingFunction`. The v2 model is `rerank-v4.0-pro` (or `rerank-english-v3.0` for backwards compat).
+**Warning signs:** HTTP 301 redirect responses, or deprecation headers in the response.
+
+---
+
+## Code Examples
+
+### BM25 Scoring Core
+```java
+// Source: derived from chroma-go/pkg/embeddings/bm25/bm25.go
+// Per-document BM25 (no corpus IDF — stateless)
+private SparseVector embedSingle(String text) throws EFException {
+    List<String> tokens = tokenizer.tokenize(text);
+    int docLen = tokens.size();
+
+    // Count term frequencies
+    Map<String, Integer> tf = new LinkedHashMap<String, Integer>();
+    for (String token : tokens) {
+        Integer count = tf.get(token);
+        tf.put(token, count == null ? 1 : count + 1);
+    }
+
+    // Compute BM25 scores and hash to indices
+    // K=1.2, B=0.75, avgDocLen set at construction time (default: 256)
+    Map<Integer, Float> indexScores = new LinkedHashMap<Integer, Float>();
+    for (Map.Entry<String, Integer> entry : tf.entrySet()) {
+        float tfVal = entry.getValue();
+        float score = (tfVal * (K + 1)) / (tfVal + K * (1 - B + B * docLen / avgDocLen));
+        int idx = Murmur3.hash32(entry.getKey().getBytes(StandardCharsets.UTF_8), 0);
+        Float existing = indexScores.get(idx);
+        indexScores.put(idx, existing == null ? score : existing + score); // collision: sum scores
+    }
+
+    // Sort by index, build arrays
+    List<Integer> sortedIndices = new ArrayList<Integer>(indexScores.keySet());
+    Collections.sort(sortedIndices);
+    int[] indices = new int[sortedIndices.size()];
+    float[] values = new float[sortedIndices.size()];
+    for (int i = 0; i < sortedIndices.size(); i++) {
+        indices[i] = sortedIndices.get(i);
+        values[i] = indexScores.get(sortedIndices.get(i));
+    }
+    return SparseVector.of(indices, values);
+}
+```
+
+### Voyage Embeddings (OkHttp)
+```java
+// Source: docs.voyageai.com/reference/embeddings-api (verified 2026-04-01)
+// POST https://api.voyageai.com/v1/embeddings
+// Auth: Authorization: Bearer $VOYAGE_API_KEY
+// Body: { "input": [...], "model": "voyage-3.5", "input_type": "document" }
+// Response: { "data": [{"embedding": [...], "index": 0}], "usage": {...} }
+
+Request request = new Request.Builder()
+    .url(baseAPI)
+    .post(RequestBody.create(gson.toJson(reqBody), JSON))
+    .addHeader("Authorization", "Bearer " + apiKey)
+    .addHeader("Content-Type", "application/json")
+    .build();
+```
+
+### Cohere Rerank v2 (OkHttp)
+```java
+// Source: docs.cohere.com/reference/rerank (verified 2026-04-01)
+// POST https://api.cohere.com/v2/rerank
+// Auth: Authorization: Bearer $COHERE_API_KEY
+// Body: { "model": "rerank-v4.0-pro", "query": "...", "documents": [...] }
+// Response: { "results": [{"index": 0, "relevance_score": 0.95}] }
+
+Request request = new Request.Builder()
+    .url("https://api.cohere.com/v2/rerank")
+    .post(RequestBody.create(gson.toJson(reqBody), JSON))
+    .addHeader("Authorization", "Bearer " + apiKey)
+    .addHeader("Content-Type", "application/json")
+    .build();
+```
+
+### Jina Reranker (OkHttp)
+```java
+// Source: jina.ai/reranker + verified via web search (2026-04-01)
+// POST https://api.jina.ai/v1/rerank
+// Auth: Authorization: Bearer $JINA_API_KEY
+// Body: { "model": "jina-reranker-v2-base-multilingual", "query": "...", "documents": [...] }
+// Response: { "results": [{"index": 0, "relevance_score": 0.9}] }
+```
+
+### Gemini Embeddings (Google GenAI SDK)
+```java
+// Source: google-genai SDK (com.google.genai:google-genai:1.2.0, Java 8 compatible)
+// Provider name: "google_genai" (matches Go client)
+// Default model: "gemini-embedding-2-preview" (matches Go client constant)
+// Env var: GEMINI_API_KEY
+
+// SDK usage (Java 8 style — no var keyword):
+Client genaiClient = Client.builder().apiKey(apiKey).build();
+EmbedContentResponse response = genaiClient.models().embedContent(
+    modelName,
+    Content.fromParts(Part.fromText(text)),
+    null
+);
+float[] vector = toFloatArray(response.embedding().values());
+```
+
+### AWS Bedrock Embeddings (bedrockruntime SDK)
+```java
+// Source: AWS SDK v2 bedrockruntime (software.amazon.awssdk:bedrockruntime:2.34.0)
+// Provider name: "amazon_bedrock" (matches Go client)
+// Default model: "amazon.titan-embed-text-v1" (matches Go client default)
+// Auth: AWS SDK credential chain (env vars, ~/.aws/credentials, EC2 role, etc.)
+
+BedrockRuntimeClient bedrockClient = BedrockRuntimeClient.builder()
+    .region(Region.of(region))
+    .build();
+
+String body = "{\"inputText\":\"" + text + "\"}";
+InvokeModelResponse response = bedrockClient.invokeModel(InvokeModelRequest.builder()
+    .modelId(modelId)
+    .body(SdkBytes.fromUtf8String(body))
+    .build());
+// Parse JSON response: response.body().asUtf8String() → { "embedding": [...] }
+```
+
+### Modality Enum (follows DistanceFunction pattern)
+```java
+// Source: existing DistanceFunction.java pattern in this codebase
+public enum Modality {
+    TEXT("text"),
+    IMAGE("image"),
+    AUDIO("audio"),
+    VIDEO("video"),
+    PDF("pdf");
+
+    private final String value;
+    Modality(String value) { this.value = value; }
+    public String getValue() { return value; }
+
+    public static Modality fromValue(String value) {
+        if (value == null) throw new IllegalArgumentException("value must not be null");
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        for (Modality m : values()) {
+            if (m.value.equals(normalized)) return m;
+        }
+        throw new IllegalArgumentException("Unknown modality: " + value);
+    }
+}
+```
+
+---
+
+## BM25 Stop Words (verified from Go client)
+
+174 words matching Go `DEFAULT_CHROMA_BM25_STOPWORDS` (NLTK English base):
+
+```
+a, about, above, after, again, against, ain, all, am, an, and, any, are, aren,
+aren't, as, at, be, because, been, before, being, below, between, both, but, by,
+can, couldn, couldn't, d, did, didn, didn't, do, does, doesn, doesn't, doing, don,
+don't, down, during, each, few, for, from, further, had, hadn, hadn't, has, hasn,
+hasn't, have, haven, haven't, having, he, her, here, hers, herself, him, himself,
+his, how, i, if, in, into, is, isn, isn't, it, it's, its, itself, just, ll, m,
+ma, me, mightn, mightn't, more, most, mustn, mustn't, my, myself, needn, needn't,
+no, nor, not, now, o, of, off, on, once, only, or, other, our, ours, ourselves,
+out, over, own, re, s, same, shan, shan't, she, she's, should, should've, shouldn,
+shouldn't, so, some, such, t, than, that, that'll, the, their, theirs, them,
+themselves, then, there, these, they, this, those, through, to, too, under, until,
+up, ve, very, was, wasn, wasn't, we, were, weren, weren't, what, when, where,
+which, while, who, whom, why, will, with, won, won't, wouldn, wouldn't, y, you,
+you'd, you'll, you're, you've, your, yours, yourself, yourselves
+```
+
+---
+
+## API Wire Formats Reference
+
+### Chroma Cloud Splade
+- **Endpoint:** `POST https://embed.trychroma.com/embed_sparse`
+- **Auth:** `x-chroma-token: <token>` header
+- **Response:** `{ "indices": [...], "values": [...] }` per document
+
+### Voyage AI Embeddings
+- **Endpoint:** `POST https://api.voyageai.com/v1/embeddings`
+- **Auth:** `Authorization: Bearer $VOYAGE_API_KEY`
+- **Request:** `{ "input": ["..."], "model": "voyage-3.5", "input_type": "document" }`
+- **Response:** `{ "data": [{"embedding": [...], "index": 0}], "usage": {"total_tokens": N} }`
+- **Default model (Java):** Use `"voyage-2"` (Go client default) for consistency; optionally expose `"voyage-3.5"` as updated default
+
+### Cohere Rerank v2
+- **Endpoint:** `POST https://api.cohere.com/v2/rerank`
+- **Auth:** `Authorization: Bearer $COHERE_API_KEY`
+- **Request:** `{ "model": "rerank-english-v3.0", "query": "...", "documents": ["..."] }`
+- **Response:** `{ "results": [{"index": 0, "relevance_score": 0.95}] }`
+
+### Jina Reranker
+- **Endpoint:** `POST https://api.jina.ai/v1/rerank`
+- **Auth:** `Authorization: Bearer $JINA_API_KEY`
+- **Request:** `{ "model": "jina-reranker-v2-base-multilingual", "query": "...", "documents": ["..."] }`
+- **Response:** `{ "results": [{"index": 0, "relevance_score": 0.9}] }`
+
+---
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Cohere rerank v1 API (`api.cohere.ai/v1/rerank`) | v2 API (`api.cohere.com/v2/rerank`) | 2024 | Use new endpoint and model names (`rerank-v4.0-pro`) |
+| Gemini embedding SDK via `com.google.ai.client.generativeai` | `com.google.genai:google-genai` (new GA SDK) | May 2025 | New artifact ID; old SDK is deprecated |
+| AWS SDK v1 (`com.amazonaws:aws-java-sdk-bedrock`) | AWS SDK v2 (`software.amazon.awssdk:bedrockruntime`) | SDK v1 end-of-life 2025-12-31 | Use v2 only |
+
+**Deprecated/outdated:**
+- `com.google.ai.client.generativeai` (old Gemini SDK): replaced by `com.google.genai:google-genai`
+- `com.amazonaws:aws-java-sdk-bedrock` (AWS SDK v1): end-of-life December 2025; use `software.amazon.awssdk:bedrockruntime`
+- Cohere v1 API base URL `api.cohere.ai`: moved to `api.cohere.com` for v2
+
+---
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| Java 8+ | All | ✓ | Enforced by pom.xml `animal-sniffer` | — |
+| Maven | Build | ✓ | (project standard) | — |
+| OkHttp 4.12.0 | Voyage, Splade, Cohere Rerank, Jina | ✓ | Already in pom.xml | — |
+| Gson 2.10.1 | All provider DTOs | ✓ | Already in pom.xml | — |
+| WireMock (test) | Unit tests for new providers | ✓ | Already in test scope | — |
+| `GEMINI_API_KEY` env var | Gemini integration tests | ✗ (likely) | — | Skip integration test with `Assume.assumeNotNull` |
+| `VOYAGE_API_KEY` env var | Voyage integration tests | ✗ (likely) | — | Skip integration test with `Assume.assumeNotNull` |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Bedrock integration tests | ✗ (likely) | — | Skip integration test with `Assume.assumeNotNull` |
+| `COHERE_API_KEY` env var | Cohere Rerank integration tests | ✗ (likely) | — | Skip integration test with `Assume.assumeNotNull` |
+| `JINA_API_KEY` env var | Jina Reranker integration tests | ✗ (likely) | — | Skip integration test with `Assume.assumeNotNull` |
+| Google GenAI SDK (`com.google.genai:google-genai:1.2.0`) | Gemini provider compile | ✗ (not in pom) | — | Must add as `<optional>true</optional>` dep |
+| AWS Bedrock SDK (`software.amazon.awssdk:bedrockruntime:2.34.0`) | Bedrock provider compile | ✗ (not in pom) | — | Must add as `<optional>true</optional>` dep |
+| Snowball stemmer (`com.github.rholder:snowball-stemmer:1.3.0.581.1`) | BM25 tokenizer | ✗ (not in pom) | — | Must add as `compile` dep |
+
+**Missing dependencies with no fallback:**
+- `com.github.rholder:snowball-stemmer` — blocking for BM25; must be added to pom.xml as compile dep
+- `com.google.genai:google-genai` — blocking for Gemini provider compilation; must be added as optional
+- `software.amazon.awssdk:bedrockruntime` — blocking for Bedrock provider compilation; must be added as optional
+
+**Missing dependencies with fallback:**
+- All API key env vars — integration tests gated with `Assume.assumeNotNull(System.getenv("KEY_NAME"))` per existing conformance test pattern
+
+---
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | JUnit 4.13.2 |
+| Config file | none (uses maven-surefire-plugin patterns in pom.xml) |
+| Quick run command | `mvn test -Dtest=EmbeddingFunctionRegistryTest,BM25EmbeddingFunctionTest,SparseEmbeddingFunctionTest,ContentEmbeddingFunctionTest,RerankingFunctionTest` |
+| Full suite command | `mvn test` |
+| Integration tests | `mvn test -Pintegration -Dtest=GeminiConformanceIntegrationTest,VoyageConformanceIntegrationTest` |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| EMB-05 | BM25 tokenizes and produces SparseVector with correct indices/values | unit | `mvn test -Dtest=BM25EmbeddingFunctionTest` | ❌ Wave 0 |
+| EMB-05 | BM25 stop words match Go client list | unit | `mvn test -Dtest=BM25TokenizerTest` | ❌ Wave 0 |
+| EMB-05 | BM25 Murmur3 hashing matches cross-client test vectors | unit | `mvn test -Dtest=Murmur3Test` | ❌ Wave 0 |
+| EMB-05 | SparseEmbeddingFunction interface: null/empty rejection | unit | `mvn test -Dtest=SparseEmbeddingConformanceTest` | ❌ Wave 0 |
+| EMB-05 | Chroma Cloud Splade provider (WireMock) | unit | `mvn test -Dtest=ChromaCloudSpladeEmbeddingFunctionTest` | ❌ Wave 0 |
+| EMB-06 | Content/Part/BinarySource value types: construction, equality | unit | `mvn test -Dtest=ContentTypesTest` | ❌ Wave 0 |
+| EMB-06 | ContentEmbeddingFunction adapter wraps EmbeddingFunction correctly | unit | `mvn test -Dtest=ContentEmbeddingAdapterTest` | ❌ Wave 0 |
+| EMB-07 | Voyage provider: null rejection, error wrapping, success (WireMock) | unit | `mvn test -Dtest=VoyageConformanceTest` | ❌ Wave 0 |
+| EMB-07 | Gemini provider: compiles and constructs with optional SDK absent → clear error | unit | `mvn test -Dtest=GeminiEmbeddingFunctionTest` | ❌ Wave 0 |
+| EMB-07 | Bedrock provider: compiles and constructs with optional SDK absent → clear error | unit | `mvn test -Dtest=BedrockEmbeddingFunctionTest` | ❌ Wave 0 |
+| EMB-08 | Registry: register dense/sparse/content, resolve by name | unit | `mvn test -Dtest=EmbeddingFunctionRegistryTest` | ❌ Wave 0 |
+| EMB-08 | Registry: content fallback chain (dense → adapter when no content factory) | unit | `mvn test -Dtest=EmbeddingFunctionRegistryTest#testContentFallbackChain` | ❌ Wave 0 |
+| EMB-08 | Registry singleton pre-registers all built-in providers | unit | `mvn test -Dtest=EmbeddingFunctionRegistryTest#testDefaultRegistryHasBuiltins` | ❌ Wave 0 |
+| EMB-08 | Registry: duplicate registration rejected | unit | `mvn test -Dtest=EmbeddingFunctionRegistryTest#testDuplicateRegistrationRejected` | ❌ Wave 0 |
+| RERANK-01 | RerankingFunction interface + RerankResult value type | unit | `mvn test -Dtest=RerankResultTest` | ❌ Wave 0 |
+| RERANK-01 | Cohere Rerank provider: success and error cases (WireMock) | unit | `mvn test -Dtest=CohereRerankingFunctionTest` | ❌ Wave 0 |
+| RERANK-01 | Jina Reranker provider: success and error cases (WireMock) | unit | `mvn test -Dtest=JinaRerankingFunctionTest` | ❌ Wave 0 |
+
+### Sampling Rate
+- **Per task commit:** Quick test run targeting the files changed in that task
+- **Per wave merge:** `mvn test` (all unit tests)
+- **Phase gate:** `mvn test` full suite green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+All test files listed above are new and must be created in Wave 0 (or alongside implementation):
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/BM25EmbeddingFunctionTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/BM25TokenizerTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/Murmur3Test.java` (cross-client test vectors)
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/SparseEmbeddingConformanceTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunctionTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/content/ContentTypesTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/ContentEmbeddingAdapterTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/voyage/VoyageConformanceTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunctionTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunctionTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistryTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/reranking/RerankResultTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunctionTest.java`
+- [ ] `src/test/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunctionTest.java`
+
+*(All WireMock conformance tests follow the existing `AbstractEmbeddingFunctionConformanceTest` pattern)*
+
+---
+
+## Open Questions
+
+1. **Voyage default model name**
+   - What we know: Go client uses `"voyage-2"` as default. Voyage AI has since released `voyage-3.5` (and `voyage-4-large`).
+   - What's unclear: Whether to use Go-compatible default (`"voyage-2"`) or updated default (`"voyage-3.5"`).
+   - Recommendation: Use `"voyage-2"` as the default for Go client compatibility (matches `WithParam.defaultModel()`). Document the newer models in Javadoc. Users can override with `WithParam.model("voyage-3.5")`.
+
+2. **EmbeddingFunctionRegistry thread safety model**
+   - What we know: D-20 says "thread-safe with synchronized access". Go uses `sync.RWMutex` (multiple readers, single writer).
+   - What's unclear: Whether to use `synchronized` methods (simple) or `java.util.concurrent.ConcurrentHashMap` (better read concurrency).
+   - Recommendation: Use `synchronized` on register methods + `Collections.unmodifiableMap` snapshot for reads. The registry is write-once-at-startup in practice; high read concurrency is not a real concern.
+
+3. **Gemini model name change**
+   - What we know: Go client uses `"gemini-embedding-2-preview"` as default. The model ID naming convention for Google changes frequently.
+   - What's unclear: Whether `"gemini-embedding-2-preview"` is still valid in the `google-genai` 1.2.0 SDK as of 2026.
+   - Recommendation: Use the same default as the Go client (`"gemini-embedding-2-preview"`) for now. If Gemini integration test fails, the error will clarify the current model name. Low risk since the model param is user-overridable.
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+- Codebase: `src/main/java/tech/amikos/chromadb/embeddings/` — existing EF patterns, WithParam, OkHttp usage
+- Codebase: `src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java` — existing auto-wiring logic
+- Codebase: `src/main/java/tech/amikos/chromadb/v2/SparseVector.java` — reuse as return type
+- Codebase: `src/main/java/tech/amikos/chromadb/v2/DistanceFunction.java` — enum pattern for Modality/Intent
+- GitHub raw: `chroma-go/pkg/embeddings/bm25/tokenizer.go` — tokenizer pipeline (lowercase, regex, stopword filter, stemmer)
+- GitHub raw: `chroma-go/pkg/embeddings/bm25/bm25.go` — BM25 scoring, Murmur3 hashing, SparseVector output
+- GitHub raw: `chroma-go/pkg/embeddings/bm25/stopwords.go` — 174 English stop words
+- GitHub raw: `chroma-go/pkg/embeddings/registry.go` — registry pattern (4 maps, singleton, content fallback chain)
+- GitHub raw: `chroma-go/pkg/rerankings/reranking.go` — RerankingFunction interface, RankedResult type
+- GitHub raw: `chroma-go/pkg/rerankings/cohere/cohere.go` — Cohere rerank implementation
+- GitHub raw: `chroma-go/pkg/rerankings/jina/jina.go` — Jina reranker implementation
+- Official docs: `docs.voyageai.com/reference/embeddings-api` — endpoint, request/response format, auth
+- Official docs: `docs.cohere.com/reference/rerank` — v2 endpoint, request/response format, auth
+- Maven Central: `com.google.genai:google-genai:1.2.0` — verified 2026-04-01
+- Maven Central: `software.amazon.awssdk:bedrockruntime:2.34.0` — verified 2026-04-01
+- Maven Central: `com.github.rholder:snowball-stemmer:1.3.0.581.1` — verified 2026-04-01
+- `googleapis/java-genai` pom.xml — Java 8 compatibility confirmed (`maven.compiler.source=1.8`)
+
+### Secondary (MEDIUM confidence)
+- WebSearch verified: AWS SDK v2 requires Java 8+ (multiple official AWS docs confirm)
+- WebSearch verified: Jina reranker endpoint `https://api.jina.ai/v1/rerank`, Bearer auth (jina.ai/reranker)
+- Go client `gemini.go` Name() method: `"google_genai"`, default model `"gemini-embedding-2-preview"`
+- Go client `voyage.go` Name() method: `"voyageai"`, env var: `"VOYAGE_API_KEY"`, default: `"voyage-2"`
+- Go client `bedrock.go` Name() method: `"amazon_bedrock"`, default model: `"amazon.titan-embed-text-v1"`
+- Go client `chromacloudsplade.go` Name() method: `"chroma-cloud-splade"`, endpoint: `"https://embed.trychroma.com/embed_sparse"`
+
+### Tertiary (LOW confidence)
+- None — all critical claims verified via primary or secondary sources.
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — all versions verified against Maven Central 2026-04-01
+- Architecture patterns: HIGH — derived from existing codebase patterns + Go reference client
+- BM25 pipeline: HIGH — verified directly from Go source files
+- API wire formats: HIGH — verified from official provider documentation
+- Vendor SDK Java 8 compat: HIGH — confirmed via pom.xml inspection (google-genai) and official docs (AWS SDK v2)
+- Pitfalls: HIGH — derived from concrete codebase analysis and known library behaviors
+
+**Research date:** 2026-04-01
+**Valid until:** 2026-07-01 (stable domain; API endpoints and SDK versions may drift after 90 days)

--- a/.planning/phases/04-embedding-ecosystem/04-UAT.md
+++ b/.planning/phases/04-embedding-ecosystem/04-UAT.md
@@ -1,0 +1,62 @@
+---
+status: complete
+phase: 04-embedding-ecosystem
+source: [04-01-SUMMARY.md, 04-02-SUMMARY.md, 04-03-SUMMARY.md, 04-04-SUMMARY.md, 04-05-SUMMARY.md]
+started: 2026-04-01T17:15:00Z
+updated: 2026-04-01T17:20:00Z
+---
+
+## Current Test
+
+[testing complete]
+
+## Tests
+
+### 1. SparseEmbeddingFunction produces SparseVector
+expected: BM25EmbeddingFunction.embedQuery("the quick brown fox") returns SparseVector with sorted int[] indices and float[] values, both non-empty.
+result: pass
+
+### 2. ContentEmbeddingFunction adapter round-trip
+expected: ContentEmbeddingFunction.fromTextOnly(existingDenseEF) wraps any existing EmbeddingFunction. Calling embedContent(Content.text("hello")) delegates to the wrapped EF and returns an Embedding.
+result: pass
+
+### 3. Content value types build correctly
+expected: Content.text("hello") creates single-part text content. Content.builder().part(Part.image(BinarySource.fromUrl("http://img"))).intent(Intent.RETRIEVAL_DOCUMENT).build() creates multimodal content. Parts list is unmodifiable.
+result: pass
+
+### 4. Reranking with Cohere/Jina providers
+expected: CohereRerankingFunction(WithParam.apiKey("key")).rerank("query", docs) POSTs to Cohere v2/rerank endpoint. JinaRerankingFunction similarly POSTs to Jina v1/rerank. Both return List<RerankResult> sorted by descending relevance score.
+result: pass
+
+### 5. Gemini/Bedrock/Voyage provider construction
+expected: GeminiEmbeddingFunction(WithParam.apiKey("key")) constructs without error using lazy client init. BedrockEmbeddingFunction() constructs using AWS default credentials. VoyageEmbeddingFunction(WithParam.apiKey("key")) constructs with OkHttp client. All three are optional Maven deps.
+result: pass
+
+### 6. BM25 tokenizer pipeline matches Go client
+expected: BM25Tokenizer.tokenize("The quick brown fox") filters stop word "the", lowercases, stems with Snowball English stemmer. Murmur3.hash32("hello".getBytes(UTF_8), 0) produces consistent 32-bit hash matching Python mmh3 output.
+result: pass
+
+### 7. EmbeddingFunctionRegistry resolves built-in providers
+expected: EmbeddingFunctionRegistry.getDefault().resolveDense(spec("openai")) returns OpenAIEmbeddingFunction. resolveSparse(spec("bm25")) returns BM25EmbeddingFunction. resolveContent(spec("openai")) returns ContentEmbeddingFunction via dense+adapter fallback.
+result: pass
+
+### 8. EmbeddingFunctionRegistry custom registration
+expected: new EmbeddingFunctionRegistry().registerDense("custom", factory) then resolveDense(spec("custom")) returns the factory result. Thread-safe: concurrent register/resolve calls don't corrupt state.
+result: pass
+
+### 9. Full test suite passes with no regressions
+expected: `mvn test` passes all ~1209 tests with 0 failures and 0 errors (excluding flaky WireMock timeouts).
+result: pass
+
+## Summary
+
+total: 9
+passed: 9
+issues: 0
+pending: 0
+skipped: 0
+blocked: 0
+
+## Gaps
+
+[none]

--- a/.planning/phases/04-embedding-ecosystem/04-VALIDATION.md
+++ b/.planning/phases/04-embedding-ecosystem/04-VALIDATION.md
@@ -38,11 +38,11 @@ created: 2026-04-01
 
 | Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
 |---------|------|------|-------------|-----------|-------------------|-------------|--------|
-| TBD | 01 | 1 | EMB-05 | unit | `mvn test -Dtest=TestSparseEmbeddingFunction` | ❌ W0 | ⬜ pending |
-| TBD | 01 | 1 | EMB-06 | unit | `mvn test -Dtest=TestContentEmbeddingFunction` | ❌ W0 | ⬜ pending |
-| TBD | 02 | 1 | EMB-07 | unit | `mvn test -Dtest=TestGeminiEmbeddingFunction,TestBedrockEmbeddingFunction,TestVoyageEmbeddingFunction` | ❌ W0 | ⬜ pending |
-| TBD | 02 | 1 | RERANK-01 | unit | `mvn test -Dtest=TestCohereRerankFunction,TestJinaRerankFunction` | ❌ W0 | ⬜ pending |
-| TBD | 03 | 2 | EMB-08 | unit | `mvn test -Dtest=TestEmbeddingFunctionRegistry` | ❌ W0 | ⬜ pending |
+| TBD | 01 | 1 | EMB-05, EMB-06 | unit | `mvn test -Dtest=TestSparseEmbeddingFunction,TestContentEmbeddingFunction` | ❌ W0 | ⬜ pending |
+| TBD | 02 | 1 | RERANK-01 | unit | `mvn test -Dtest=TestCohereRerankingFunction,TestJinaRerankingFunction` | ❌ W0 | ⬜ pending |
+| TBD | 03 | 1 | EMB-07 | unit | `mvn test -Dtest=TestGeminiEmbeddingFunction,TestBedrockEmbeddingFunction,TestVoyageEmbeddingFunction` | ❌ W0 | ⬜ pending |
+| TBD | 04 | 2 | EMB-05 | unit | `mvn test -Dtest=TestBM25EmbeddingFunction,TestChromaCloudSpladeEmbeddingFunction` | ❌ W0 | ⬜ pending |
+| TBD | 05 | 2 | EMB-08 | unit | `mvn test -Dtest=TestEmbeddingFunctionRegistry` | ❌ W0 | ⬜ pending |
 
 *Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
 

--- a/.planning/phases/04-embedding-ecosystem/04-VALIDATION.md
+++ b/.planning/phases/04-embedding-ecosystem/04-VALIDATION.md
@@ -1,0 +1,83 @@
+---
+phase: 4
+slug: embedding-ecosystem
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-04-01
+---
+
+# Phase 4 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | JUnit 5 + Maven Surefire |
+| **Config file** | `pom.xml` (surefire plugin already configured) |
+| **Quick run command** | `mvn test -Dtest=TestClassName` |
+| **Full suite command** | `mvn test` |
+| **Estimated runtime** | ~120 seconds (with TestContainers) |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `mvn test -Dtest=<relevant test class>`
+- **After every plan wave:** Run `mvn test`
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 120 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| TBD | 01 | 1 | EMB-05 | unit | `mvn test -Dtest=TestSparseEmbeddingFunction` | ❌ W0 | ⬜ pending |
+| TBD | 01 | 1 | EMB-06 | unit | `mvn test -Dtest=TestContentEmbeddingFunction` | ❌ W0 | ⬜ pending |
+| TBD | 02 | 1 | EMB-07 | unit | `mvn test -Dtest=TestGeminiEmbeddingFunction,TestBedrockEmbeddingFunction,TestVoyageEmbeddingFunction` | ❌ W0 | ⬜ pending |
+| TBD | 02 | 1 | RERANK-01 | unit | `mvn test -Dtest=TestCohereRerankFunction,TestJinaRerankFunction` | ❌ W0 | ⬜ pending |
+| TBD | 03 | 2 | EMB-08 | unit | `mvn test -Dtest=TestEmbeddingFunctionRegistry` | ❌ W0 | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] Test stubs for sparse/content interfaces — EMB-05, EMB-06
+- [ ] Test stubs for new dense providers — EMB-07
+- [ ] Test stubs for reranking — RERANK-01
+- [ ] Test stubs for registry — EMB-08
+
+*Existing test infrastructure (JUnit 5, Surefire, TestContainers) covers framework needs.*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Gemini API integration | EMB-07 | Requires GOOGLE_API_KEY | Set env var, run `mvn test -Dtest=TestGeminiEmbeddingFunction` |
+| Bedrock API integration | EMB-07 | Requires AWS credentials | Set env vars, run `mvn test -Dtest=TestBedrockEmbeddingFunction` |
+| Voyage API integration | EMB-07 | Requires VOYAGE_API_KEY | Set env var, run `mvn test -Dtest=TestVoyageEmbeddingFunction` |
+| Cohere Rerank integration | RERANK-01 | Requires COHERE_API_KEY | Set env var, run `mvn test -Dtest=TestCohereRerankFunction` |
+| Jina Rerank integration | RERANK-01 | Requires JINA_API_KEY | Set env var, run `mvn test -Dtest=TestJinaRerankFunction` |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 120s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- BM25: Snowball stemmer for English text stemming -->
+        <dependency>
+            <groupId>com.github.rholder</groupId>
+            <artifactId>snowball-stemmer</artifactId>
+            <version>1.3.0.581.1</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Align Jackson core version across all transitive deps (nd4j pulls 2.13, GenAI SDK needs 2.17+) -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.17.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.17.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,22 @@
             <version>1.27.0</version>
         </dependency>
 
+        <!-- Gemini embeddings (optional: user must add to their project) -->
+        <dependency>
+            <groupId>com.google.genai</groupId>
+            <artifactId>google-genai</artifactId>
+            <version>1.2.0</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- AWS Bedrock embeddings (optional: user must add to their project) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>bedrockruntime</artifactId>
+            <version>2.34.0</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java
@@ -1,0 +1,57 @@
+package tech.amikos.chromadb.embeddings;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.content.Content;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Embedding function interface for content-based (multimodal) embeddings.
+ *
+ * <p>Unlike {@link EmbeddingFunction} which only accepts text strings, this interface
+ * accepts {@link Content} objects that can contain text, images, audio, or video parts.
+ * Providers like Gemini or CLIP that support multimodal input implement this interface
+ * directly.</p>
+ *
+ * <p>Use {@link #fromTextOnly(EmbeddingFunction)} to wrap any text-only embedding function
+ * as a {@code ContentEmbeddingFunction}.</p>
+ */
+public interface ContentEmbeddingFunction {
+
+    /**
+     * Embeds multiple content objects into dense vectors.
+     *
+     * @param contents the content objects to embed
+     * @return a list of embeddings, one per content object
+     * @throws EFException if embedding fails
+     */
+    List<Embedding> embedContents(List<Content> contents) throws EFException;
+
+    /**
+     * Embeds a single content object into a dense vector.
+     *
+     * <p>Default implementation delegates to {@link #embedContents(List)}.</p>
+     *
+     * @param content the content to embed
+     * @return the embedding
+     * @throws EFException if embedding fails
+     */
+    default Embedding embedContent(Content content) throws EFException {
+        return embedContents(Collections.singletonList(content)).get(0);
+    }
+
+    /**
+     * Wraps a text-only {@link EmbeddingFunction} as a {@code ContentEmbeddingFunction}.
+     *
+     * <p>The returned adapter extracts text parts from each {@link Content} and delegates
+     * to the wrapped function.</p>
+     *
+     * @param ef the text-only embedding function to wrap
+     * @return a content embedding function that delegates to the text-only function
+     */
+    static ContentEmbeddingFunction fromTextOnly(EmbeddingFunction ef) {
+        return new TextEmbeddingAdapter(ef);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/ContentEmbeddingFunction.java
@@ -39,7 +39,11 @@ public interface ContentEmbeddingFunction {
      * @throws EFException if embedding fails
      */
     default Embedding embedContent(Content content) throws EFException {
-        return embedContents(Collections.singletonList(content)).get(0);
+        List<Embedding> embeddings = embedContents(Collections.singletonList(content));
+        if (embeddings == null || embeddings.isEmpty()) {
+            throw new EFException("embedContents returned no embeddings");
+        }
+        return embeddings.get(0);
     }
 
     /**

--- a/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
@@ -60,6 +60,9 @@ public final class ContentToTextAdapter implements EmbeddingFunction {
 
     @Override
     public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        if (documents == null) {
+            return embedDocuments((List<String>) null);
+        }
         return embedDocuments(Arrays.asList(documents));
     }
 }

--- a/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
@@ -1,0 +1,47 @@
+package tech.amikos.chromadb.embeddings;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.content.Content;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Adapter that wraps a {@link ContentEmbeddingFunction} as a text-only
+ * {@link EmbeddingFunction}.
+ *
+ * <p>Converts each input string to {@link Content#text(String)} and delegates to the
+ * wrapped content embedding function.</p>
+ */
+public class ContentToTextAdapter implements EmbeddingFunction {
+
+    private final ContentEmbeddingFunction wrapped;
+
+    public ContentToTextAdapter(ContentEmbeddingFunction wrapped) {
+        if (wrapped == null) {
+            throw new IllegalArgumentException("wrapped content embedding function must not be null");
+        }
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public Embedding embedQuery(String query) throws EFException {
+        return wrapped.embedContent(Content.text(query));
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        List<Content> contents = new ArrayList<Content>(documents.size());
+        for (String doc : documents) {
+            contents.add(Content.text(doc));
+        }
+        return wrapped.embedContents(contents);
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        return embedDocuments(Arrays.asList(documents));
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
@@ -45,7 +45,11 @@ public final class ContentToTextAdapter implements EmbeddingFunction {
             throw new IllegalArgumentException("documents must not be null");
         }
         List<Content> contents = new ArrayList<Content>(documents.size());
-        for (String doc : documents) {
+        for (int i = 0; i < documents.size(); i++) {
+            String doc = documents.get(i);
+            if (doc == null) {
+                throw new IllegalArgumentException("document at index " + i + " must not be null");
+            }
             contents.add(Content.builder()
                     .part(Part.text(doc))
                     .intent(Intent.RETRIEVAL_DOCUMENT)

--- a/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
@@ -30,6 +30,9 @@ public final class ContentToTextAdapter implements EmbeddingFunction {
 
     @Override
     public Embedding embedQuery(String query) throws EFException {
+        if (query == null) {
+            throw new IllegalArgumentException("query must not be null");
+        }
         return wrapped.embedContent(Content.builder()
                 .part(Part.text(query))
                 .intent(Intent.RETRIEVAL_QUERY)

--- a/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/ContentToTextAdapter.java
@@ -3,6 +3,8 @@ package tech.amikos.chromadb.embeddings;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.Embedding;
 import tech.amikos.chromadb.embeddings.content.Content;
+import tech.amikos.chromadb.embeddings.content.Intent;
+import tech.amikos.chromadb.embeddings.content.Part;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,7 +17,7 @@ import java.util.List;
  * <p>Converts each input string to {@link Content#text(String)} and delegates to the
  * wrapped content embedding function.</p>
  */
-public class ContentToTextAdapter implements EmbeddingFunction {
+public final class ContentToTextAdapter implements EmbeddingFunction {
 
     private final ContentEmbeddingFunction wrapped;
 
@@ -28,14 +30,23 @@ public class ContentToTextAdapter implements EmbeddingFunction {
 
     @Override
     public Embedding embedQuery(String query) throws EFException {
-        return wrapped.embedContent(Content.text(query));
+        return wrapped.embedContent(Content.builder()
+                .part(Part.text(query))
+                .intent(Intent.RETRIEVAL_QUERY)
+                .build());
     }
 
     @Override
     public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        if (documents == null) {
+            throw new IllegalArgumentException("documents must not be null");
+        }
         List<Content> contents = new ArrayList<Content>(documents.size());
         for (String doc : documents) {
-            contents.add(Content.text(doc));
+            contents.add(Content.builder()
+                    .part(Part.text(doc))
+                    .intent(Intent.RETRIEVAL_DOCUMENT)
+                    .build());
         }
         return wrapped.embedContents(contents);
     }

--- a/src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java
@@ -54,6 +54,7 @@ public final class EmbeddingFunctionRegistry {
     private final Map<String, DenseFactory> denseFactories = new LinkedHashMap<String, DenseFactory>();
     private final Map<String, SparseFactory> sparseFactories = new LinkedHashMap<String, SparseFactory>();
     private final Map<String, ContentFactory> contentFactories = new LinkedHashMap<String, ContentFactory>();
+    private final Map<String, String> unavailableDenseProviders = new LinkedHashMap<String, String>();
 
     /**
      * Creates an empty registry with no built-in providers.
@@ -122,6 +123,11 @@ public final class EmbeddingFunctionRegistry {
         }
         String name = resolveProviderName(spec, "dense");
         DenseFactory factory = denseFactories.get(name);
+        String unavailableReason = unavailableDenseProviders.get(name);
+        if (unavailableReason != null) {
+            throw new UnsupportedEmbeddingProviderException(
+                    "Embedding function provider '" + spec.getName() + "' is unavailable: " + unavailableReason);
+        }
         if (factory == null) {
             throw new UnsupportedEmbeddingProviderException("Unsupported embedding function provider '" + spec.getName()
                     + "'. Registered dense providers: " + denseFactories.keySet());
@@ -185,6 +191,11 @@ public final class EmbeddingFunctionRegistry {
             return null;
         }
         String name = resolveProviderName(spec, "content");
+        String unavailableReason = unavailableDenseProviders.get(name);
+        if (unavailableReason != null) {
+            throw new UnsupportedEmbeddingProviderException(
+                    "Content embedding provider '" + spec.getName() + "' is unavailable: " + unavailableReason);
+        }
 
         // Try content factory first
         ContentFactory cf = contentFactories.get(name);
@@ -294,7 +305,11 @@ public final class EmbeddingFunctionRegistry {
                 }
             });
         } catch (NoClassDefFoundError ignored) {
+            markDenseProviderUnavailable("google_genai",
+                    "requires optional dependency com.google.genai:google-genai on the classpath");
         } catch (ClassNotFoundException ignored) {
+            markDenseProviderUnavailable("google_genai",
+                    "requires optional dependency com.google.genai:google-genai on the classpath");
         }
 
         // Bedrock - guarded for optional SDK
@@ -308,7 +323,11 @@ public final class EmbeddingFunctionRegistry {
                 }
             });
         } catch (NoClassDefFoundError ignored) {
+            markDenseProviderUnavailable("amazon_bedrock",
+                    "requires optional dependency software.amazon.awssdk:bedrockruntime on the classpath");
         } catch (ClassNotFoundException ignored) {
+            markDenseProviderUnavailable("amazon_bedrock",
+                    "requires optional dependency software.amazon.awssdk:bedrockruntime on the classpath");
         }
 
         // Voyage
@@ -338,5 +357,9 @@ public final class EmbeddingFunctionRegistry {
                 return new ChromaCloudSpladeEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, ChromaCloudSpladeEmbeddingFunction.CHROMA_API_KEY_ENV));
             }
         });
+    }
+
+    private void markDenseProviderUnavailable(String name, String reason) {
+        unavailableDenseProviders.put(name.toLowerCase(Locale.ROOT), reason);
     }
 }

--- a/src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java
@@ -1,0 +1,311 @@
+package tech.amikos.chromadb.embeddings;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.bm25.BM25EmbeddingFunction;
+import tech.amikos.chromadb.embeddings.chromacloudsplade.ChromaCloudSpladeEmbeddingFunction;
+import tech.amikos.chromadb.embeddings.cohere.CohereEmbeddingFunction;
+import tech.amikos.chromadb.embeddings.hf.HuggingFaceEmbeddingFunction;
+import tech.amikos.chromadb.embeddings.ollama.OllamaEmbeddingFunction;
+import tech.amikos.chromadb.embeddings.openai.OpenAIEmbeddingFunction;
+import tech.amikos.chromadb.embeddings.voyage.VoyageEmbeddingFunction;
+import tech.amikos.chromadb.v2.ChromaException;
+import tech.amikos.chromadb.v2.EmbeddingFunctionResolver;
+import tech.amikos.chromadb.v2.EmbeddingFunctionSpec;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Registry for embedding function factories (dense, sparse, and content).
+ *
+ * <p>The default singleton instance ({@link #getDefault()}) comes pre-loaded with all built-in
+ * providers. Users can register custom providers via {@link #registerDense}, {@link #registerSparse},
+ * and {@link #registerContent}.</p>
+ *
+ * <p>All register/resolve methods are synchronized for thread safety.</p>
+ */
+public final class EmbeddingFunctionRegistry {
+
+    private static final EmbeddingFunctionRegistry DEFAULT = new EmbeddingFunctionRegistry(true);
+
+    /**
+     * Factory for creating dense embedding functions from configuration.
+     */
+    public interface DenseFactory {
+        EmbeddingFunction create(Map<String, Object> config) throws EFException;
+    }
+
+    /**
+     * Factory for creating sparse embedding functions from configuration.
+     */
+    public interface SparseFactory {
+        SparseEmbeddingFunction create(Map<String, Object> config) throws EFException;
+    }
+
+    /**
+     * Factory for creating content embedding functions from configuration.
+     */
+    public interface ContentFactory {
+        ContentEmbeddingFunction create(Map<String, Object> config) throws EFException;
+    }
+
+    private final Map<String, DenseFactory> denseFactories = new LinkedHashMap<String, DenseFactory>();
+    private final Map<String, SparseFactory> sparseFactories = new LinkedHashMap<String, SparseFactory>();
+    private final Map<String, ContentFactory> contentFactories = new LinkedHashMap<String, ContentFactory>();
+
+    /**
+     * Creates an empty registry with no built-in providers.
+     * Use this for testing or when full control over registered providers is needed.
+     */
+    public EmbeddingFunctionRegistry() {
+    }
+
+    private EmbeddingFunctionRegistry(boolean registerBuiltins) {
+        if (registerBuiltins) {
+            registerBuiltinProviders();
+        }
+    }
+
+    /**
+     * Returns the default singleton registry pre-loaded with all built-in providers.
+     *
+     * @return the shared default registry instance
+     */
+    public static EmbeddingFunctionRegistry getDefault() {
+        return DEFAULT;
+    }
+
+    /**
+     * Registers a dense embedding function factory under the given provider name.
+     *
+     * @param name    the provider name (case-insensitive)
+     * @param factory the factory to create instances
+     */
+    public synchronized void registerDense(String name, DenseFactory factory) {
+        denseFactories.put(name.toLowerCase(Locale.ROOT), factory);
+    }
+
+    /**
+     * Registers a sparse embedding function factory under the given provider name.
+     *
+     * @param name    the provider name (case-insensitive)
+     * @param factory the factory to create instances
+     */
+    public synchronized void registerSparse(String name, SparseFactory factory) {
+        sparseFactories.put(name.toLowerCase(Locale.ROOT), factory);
+    }
+
+    /**
+     * Registers a content embedding function factory under the given provider name.
+     *
+     * @param name    the provider name (case-insensitive)
+     * @param factory the factory to create instances
+     */
+    public synchronized void registerContent(String name, ContentFactory factory) {
+        contentFactories.put(name.toLowerCase(Locale.ROOT), factory);
+    }
+
+    /**
+     * Resolves a dense embedding function from a spec descriptor.
+     *
+     * <p>Returns {@code null} when {@code spec} is {@code null}.</p>
+     *
+     * @param spec the embedding function spec (may be null)
+     * @return the resolved embedding function, or null if spec is null
+     * @throws ChromaException if the provider name is unknown or initialization fails
+     */
+    public synchronized EmbeddingFunction resolveDense(EmbeddingFunctionSpec spec) {
+        if (spec == null) {
+            return null;
+        }
+        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+        DenseFactory factory = denseFactories.get(name);
+        if (factory == null) {
+            throw new ChromaException("Unsupported embedding function provider '" + spec.getName()
+                    + "'. Registered dense providers: " + denseFactories.keySet());
+        }
+        try {
+            return factory.create(spec.getConfig());
+        } catch (ChromaException e) {
+            throw e;
+        } catch (EFException e) {
+            throw new ChromaException("Failed to create dense provider '" + name + "': " + e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new ChromaException("Failed to create dense provider '" + name + "': " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Resolves a sparse embedding function from a spec descriptor.
+     *
+     * <p>Returns {@code null} when {@code spec} is {@code null}.</p>
+     *
+     * @param spec the embedding function spec (may be null)
+     * @return the resolved sparse embedding function, or null if spec is null
+     * @throws ChromaException if the provider name is unknown or initialization fails
+     */
+    public synchronized SparseEmbeddingFunction resolveSparse(EmbeddingFunctionSpec spec) {
+        if (spec == null) {
+            return null;
+        }
+        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+        SparseFactory factory = sparseFactories.get(name);
+        if (factory == null) {
+            throw new ChromaException("Unsupported sparse embedding function provider '" + spec.getName()
+                    + "'. Registered sparse providers: " + sparseFactories.keySet());
+        }
+        try {
+            return factory.create(spec.getConfig());
+        } catch (ChromaException e) {
+            throw e;
+        } catch (EFException e) {
+            throw new ChromaException("Failed to create sparse provider '" + name + "': " + e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new ChromaException("Failed to create sparse provider '" + name + "': " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Resolves a content embedding function from a spec descriptor.
+     *
+     * <p>First tries the content factory map. If no content factory is registered for the
+     * provider, falls back to the dense factory and wraps it with
+     * {@link ContentEmbeddingFunction#fromTextOnly(EmbeddingFunction)}.</p>
+     *
+     * <p>Returns {@code null} when {@code spec} is {@code null}.</p>
+     *
+     * @param spec the embedding function spec (may be null)
+     * @return the resolved content embedding function, or null if spec is null
+     * @throws ChromaException if neither content nor dense factory is found
+     */
+    public synchronized ContentEmbeddingFunction resolveContent(EmbeddingFunctionSpec spec) {
+        if (spec == null) {
+            return null;
+        }
+        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+
+        // Try content factory first
+        ContentFactory cf = contentFactories.get(name);
+        if (cf != null) {
+            try {
+                return cf.create(spec.getConfig());
+            } catch (ChromaException e) {
+                throw e;
+            } catch (EFException e) {
+                throw new ChromaException("Failed to create content provider '" + name + "': " + e.getMessage(), e);
+            }
+        }
+
+        // Fallback: try dense + adapter
+        DenseFactory df = denseFactories.get(name);
+        if (df != null) {
+            try {
+                return ContentEmbeddingFunction.fromTextOnly(df.create(spec.getConfig()));
+            } catch (ChromaException e) {
+                throw e;
+            } catch (EFException e) {
+                throw new ChromaException("Failed to create content provider '" + name + "' (via dense fallback): " + e.getMessage(), e);
+            }
+        }
+
+        throw new ChromaException("Unsupported content embedding provider '" + spec.getName()
+                + "'. Registered content providers: " + contentFactories.keySet()
+                + ", dense providers (fallback): " + denseFactories.keySet());
+    }
+
+    private void registerBuiltinProviders() {
+        // Dense providers
+        registerDense("default", new DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                return new DefaultEmbeddingFunction();
+            }
+        });
+        registerDense("openai", new DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                return new OpenAIEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, OpenAIEmbeddingFunction.OPENAI_API_KEY_ENV));
+            }
+        });
+        registerDense("cohere", new DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                return new CohereEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, CohereEmbeddingFunction.COHERE_API_KEY_ENV));
+            }
+        });
+
+        DenseFactory hfFactory = new DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                return new HuggingFaceEmbeddingFunction(EmbeddingFunctionResolver.buildHuggingFaceParams(config));
+            }
+        };
+        registerDense("huggingface", hfFactory);
+        registerDense("hugging_face", hfFactory);
+        registerDense("hf", hfFactory);
+
+        registerDense("ollama", new DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                return new OllamaEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, null));
+            }
+        });
+
+        // Gemini - guarded for optional SDK
+        try {
+            Class.forName("com.google.genai.Client");
+            registerDense("google_genai", new DenseFactory() {
+                @Override
+                public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                    return new tech.amikos.chromadb.embeddings.gemini.GeminiEmbeddingFunction(
+                            EmbeddingFunctionResolver.buildParams(config, tech.amikos.chromadb.embeddings.gemini.GeminiEmbeddingFunction.GEMINI_API_KEY_ENV));
+                }
+            });
+        } catch (NoClassDefFoundError ignored) {
+        } catch (ClassNotFoundException ignored) {
+        }
+
+        // Bedrock - guarded for optional SDK
+        try {
+            Class.forName("software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient");
+            registerDense("amazon_bedrock", new DenseFactory() {
+                @Override
+                public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                    return new tech.amikos.chromadb.embeddings.bedrock.BedrockEmbeddingFunction(
+                            EmbeddingFunctionResolver.buildParams(config, null));
+                }
+            });
+        } catch (NoClassDefFoundError ignored) {
+        } catch (ClassNotFoundException ignored) {
+        }
+
+        // Voyage
+        registerDense("voyageai", new DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                return new VoyageEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, VoyageEmbeddingFunction.VOYAGE_API_KEY_ENV));
+            }
+        });
+
+        // Sparse providers
+        registerSparse("chroma_bm25", new SparseFactory() {
+            @Override
+            public SparseEmbeddingFunction create(Map<String, Object> config) {
+                return new BM25EmbeddingFunction();
+            }
+        });
+        registerSparse("bm25", new SparseFactory() {
+            @Override
+            public SparseEmbeddingFunction create(Map<String, Object> config) {
+                return new BM25EmbeddingFunction();
+            }
+        });
+        registerSparse("chromacloud_splade", new SparseFactory() {
+            @Override
+            public SparseEmbeddingFunction create(Map<String, Object> config) throws EFException {
+                return new ChromaCloudSpladeEmbeddingFunction(EmbeddingFunctionResolver.buildParams(config, ChromaCloudSpladeEmbeddingFunction.CHROMA_API_KEY_ENV));
+            }
+        });
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/EmbeddingFunctionRegistry.java
@@ -11,6 +11,7 @@ import tech.amikos.chromadb.embeddings.voyage.VoyageEmbeddingFunction;
 import tech.amikos.chromadb.v2.ChromaException;
 import tech.amikos.chromadb.v2.EmbeddingFunctionResolver;
 import tech.amikos.chromadb.v2.EmbeddingFunctionSpec;
+import tech.amikos.chromadb.v2.UnsupportedEmbeddingProviderException;
 
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -83,7 +84,7 @@ public final class EmbeddingFunctionRegistry {
      * @param factory the factory to create instances
      */
     public synchronized void registerDense(String name, DenseFactory factory) {
-        denseFactories.put(name.toLowerCase(Locale.ROOT), factory);
+        denseFactories.put(normalizeProviderName(name, "dense"), requireFactory(factory, "dense"));
     }
 
     /**
@@ -93,7 +94,7 @@ public final class EmbeddingFunctionRegistry {
      * @param factory the factory to create instances
      */
     public synchronized void registerSparse(String name, SparseFactory factory) {
-        sparseFactories.put(name.toLowerCase(Locale.ROOT), factory);
+        sparseFactories.put(normalizeProviderName(name, "sparse"), requireFactory(factory, "sparse"));
     }
 
     /**
@@ -103,7 +104,7 @@ public final class EmbeddingFunctionRegistry {
      * @param factory the factory to create instances
      */
     public synchronized void registerContent(String name, ContentFactory factory) {
-        contentFactories.put(name.toLowerCase(Locale.ROOT), factory);
+        contentFactories.put(normalizeProviderName(name, "content"), requireFactory(factory, "content"));
     }
 
     /**
@@ -119,10 +120,10 @@ public final class EmbeddingFunctionRegistry {
         if (spec == null) {
             return null;
         }
-        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+        String name = resolveProviderName(spec, "dense");
         DenseFactory factory = denseFactories.get(name);
         if (factory == null) {
-            throw new ChromaException("Unsupported embedding function provider '" + spec.getName()
+            throw new UnsupportedEmbeddingProviderException("Unsupported embedding function provider '" + spec.getName()
                     + "'. Registered dense providers: " + denseFactories.keySet());
         }
         try {
@@ -149,10 +150,10 @@ public final class EmbeddingFunctionRegistry {
         if (spec == null) {
             return null;
         }
-        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+        String name = resolveProviderName(spec, "sparse");
         SparseFactory factory = sparseFactories.get(name);
         if (factory == null) {
-            throw new ChromaException("Unsupported sparse embedding function provider '" + spec.getName()
+            throw new UnsupportedEmbeddingProviderException("Unsupported sparse embedding function provider '" + spec.getName()
                     + "'. Registered sparse providers: " + sparseFactories.keySet());
         }
         try {
@@ -183,7 +184,7 @@ public final class EmbeddingFunctionRegistry {
         if (spec == null) {
             return null;
         }
-        String name = spec.getName().trim().toLowerCase(Locale.ROOT);
+        String name = resolveProviderName(spec, "content");
 
         // Try content factory first
         ContentFactory cf = contentFactories.get(name);
@@ -193,6 +194,8 @@ public final class EmbeddingFunctionRegistry {
             } catch (ChromaException e) {
                 throw e;
             } catch (EFException e) {
+                throw new ChromaException("Failed to create content provider '" + name + "': " + e.getMessage(), e);
+            } catch (RuntimeException e) {
                 throw new ChromaException("Failed to create content provider '" + name + "': " + e.getMessage(), e);
             }
         }
@@ -206,12 +209,40 @@ public final class EmbeddingFunctionRegistry {
                 throw e;
             } catch (EFException e) {
                 throw new ChromaException("Failed to create content provider '" + name + "' (via dense fallback): " + e.getMessage(), e);
+            } catch (RuntimeException e) {
+                throw new ChromaException("Failed to create content provider '" + name + "' (via dense fallback): " + e.getMessage(), e);
             }
         }
 
-        throw new ChromaException("Unsupported content embedding provider '" + spec.getName()
+        throw new UnsupportedEmbeddingProviderException("Unsupported content embedding provider '" + spec.getName()
                 + "'. Registered content providers: " + contentFactories.keySet()
                 + ", dense providers (fallback): " + denseFactories.keySet());
+    }
+
+    private static String normalizeProviderName(String name, String type) {
+        if (name == null) {
+            throw new IllegalArgumentException(type + " provider name must not be null");
+        }
+        String normalized = name.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(type + " provider name must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String resolveProviderName(EmbeddingFunctionSpec spec, String type) {
+        try {
+            return normalizeProviderName(spec.getName(), type);
+        } catch (IllegalArgumentException e) {
+            throw new ChromaException("Failed to resolve " + type + " provider: " + e.getMessage(), e);
+        }
+    }
+
+    private static <T> T requireFactory(T factory, String type) {
+        if (factory == null) {
+            throw new IllegalArgumentException(type + " factory must not be null");
+        }
+        return factory;
     }
 
     private void registerBuiltinProviders() {

--- a/src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/SparseEmbeddingFunction.java
@@ -1,0 +1,34 @@
+package tech.amikos.chromadb.embeddings;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.util.List;
+
+/**
+ * Embedding function interface for sparse vector representations (e.g., BM25, SPLADE).
+ *
+ * <p>This is a separate interface from {@link EmbeddingFunction} because sparse embeddings
+ * produce {@link SparseVector} (integer indices + float values) rather than dense
+ * {@link tech.amikos.chromadb.Embedding} arrays.</p>
+ */
+public interface SparseEmbeddingFunction {
+
+    /**
+     * Embeds a single query string into a sparse vector.
+     *
+     * @param query the query text
+     * @return a sparse vector representation
+     * @throws EFException if embedding fails
+     */
+    SparseVector embedQuery(String query) throws EFException;
+
+    /**
+     * Embeds multiple documents into sparse vectors.
+     *
+     * @param documents the document texts
+     * @return a list of sparse vector representations, one per document
+     * @throws EFException if embedding fails
+     */
+    List<SparseVector> embedDocuments(List<String> documents) throws EFException;
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
@@ -29,8 +29,15 @@ public final class TextEmbeddingAdapter implements ContentEmbeddingFunction {
 
     @Override
     public List<Embedding> embedContents(List<Content> contents) throws EFException {
+        if (contents == null) {
+            throw new IllegalArgumentException("contents must not be null");
+        }
         List<String> texts = new ArrayList<String>(contents.size());
-        for (Content content : contents) {
+        for (int i = 0; i < contents.size(); i++) {
+            Content content = contents.get(i);
+            if (content == null) {
+                throw new IllegalArgumentException("content at index " + i + " must not be null");
+            }
             String text = extractText(content);
             if (text == null) {
                 throw new EFException("Content has no text part");

--- a/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
@@ -16,7 +16,7 @@ import java.util.List;
  * <p>For each {@link Content}, extracts the first text {@link Part} and delegates to the
  * wrapped embedding function. Throws {@link EFException} if any content has no text part.</p>
  */
-public class TextEmbeddingAdapter implements ContentEmbeddingFunction {
+public final class TextEmbeddingAdapter implements ContentEmbeddingFunction {
 
     private final EmbeddingFunction wrapped;
 

--- a/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
@@ -47,9 +47,12 @@ public final class TextEmbeddingAdapter implements ContentEmbeddingFunction {
         return wrapped.embedDocuments(texts);
     }
 
-    private String extractText(Content content) {
+    private String extractText(Content content) throws EFException {
         for (Part part : content.getParts()) {
             if (part.getModality() == Modality.TEXT) {
+                if (part.getText() == null) {
+                    throw new EFException("Content text part must not be null");
+                }
                 return part.getText();
             }
         }

--- a/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/TextEmbeddingAdapter.java
@@ -1,0 +1,51 @@
+package tech.amikos.chromadb.embeddings;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.content.Content;
+import tech.amikos.chromadb.embeddings.content.Modality;
+import tech.amikos.chromadb.embeddings.content.Part;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter that wraps a text-only {@link EmbeddingFunction} as a
+ * {@link ContentEmbeddingFunction}.
+ *
+ * <p>For each {@link Content}, extracts the first text {@link Part} and delegates to the
+ * wrapped embedding function. Throws {@link EFException} if any content has no text part.</p>
+ */
+public class TextEmbeddingAdapter implements ContentEmbeddingFunction {
+
+    private final EmbeddingFunction wrapped;
+
+    public TextEmbeddingAdapter(EmbeddingFunction wrapped) {
+        if (wrapped == null) {
+            throw new IllegalArgumentException("wrapped embedding function must not be null");
+        }
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public List<Embedding> embedContents(List<Content> contents) throws EFException {
+        List<String> texts = new ArrayList<String>(contents.size());
+        for (Content content : contents) {
+            String text = extractText(content);
+            if (text == null) {
+                throw new EFException("Content has no text part");
+            }
+            texts.add(text);
+        }
+        return wrapped.embedDocuments(texts);
+    }
+
+    private String extractText(Content content) {
+        for (Part part : content.getParts()) {
+            if (part.getModality() == Modality.TEXT) {
+                return part.getText();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
@@ -1,0 +1,187 @@
+package tech.amikos.chromadb.embeddings.bedrock;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
+import tech.amikos.chromadb.Constants;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.EmbeddingFunction;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.v2.ChromaException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Embedding function that uses the AWS Bedrock Runtime SDK to generate embeddings.
+ *
+ * <p>Requires the {@code software.amazon.awssdk:bedrockruntime} dependency on the classpath.
+ * The dependency is declared as optional in the POM; users must add it explicitly.</p>
+ *
+ * <p>Authentication uses the AWS default credential chain (environment variables, IAM role, etc.).
+ * No API key is needed at construction time.</p>
+ */
+public class BedrockEmbeddingFunction implements EmbeddingFunction {
+
+    public static final String DEFAULT_MODEL_NAME = "amazon.titan-embed-text-v2:0";
+    public static final String AWS_REGION_ENV = "AWS_REGION";
+    static final String CONFIG_KEY_REGION = "awsRegion";
+    private static final String DEFAULT_REGION = "us-east-1";
+
+    private final Map<String, Object> configParams = new HashMap<String, Object>();
+    private volatile BedrockRuntimeClient bedrockClient;
+    private final Gson gson = new Gson();
+
+    private static final List<WithParam> defaults = Arrays.asList(
+            WithParam.defaultModel(DEFAULT_MODEL_NAME)
+    );
+
+    /**
+     * Creates a custom WithParam that sets the AWS region.
+     *
+     * @param region AWS region string (e.g. "us-east-1", "eu-west-1")
+     * @return a WithParam that configures the region
+     */
+    public static WithParam region(String region) {
+        return new WithRegion(region);
+    }
+
+    /**
+     * Creates a BedrockEmbeddingFunction with default settings.
+     * Uses the default model and us-east-1 region.
+     *
+     * @throws EFException if parameter application fails
+     */
+    public BedrockEmbeddingFunction() throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+    }
+
+    /**
+     * Creates a BedrockEmbeddingFunction with the given parameters.
+     *
+     * @param params configuration parameters (model, region, etc.)
+     * @throws EFException if parameter application fails
+     */
+    public BedrockEmbeddingFunction(WithParam... params) throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        for (WithParam param : params) {
+            param.apply(this.configParams);
+        }
+    }
+
+    private BedrockRuntimeClient getClient() {
+        if (bedrockClient == null) {
+            synchronized (this) {
+                if (bedrockClient == null) {
+                    String regionStr = configParams.containsKey(CONFIG_KEY_REGION)
+                            ? configParams.get(CONFIG_KEY_REGION).toString()
+                            : System.getenv(AWS_REGION_ENV) != null
+                            ? System.getenv(AWS_REGION_ENV)
+                            : DEFAULT_REGION;
+                    bedrockClient = BedrockRuntimeClient.builder()
+                            .region(Region.of(regionStr))
+                            .build();
+                }
+            }
+        }
+        return bedrockClient;
+    }
+
+    @Override
+    public Embedding embedQuery(String query) throws EFException {
+        if (query == null) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+        }
+        return embedDocuments(Collections.singletonList(query)).get(0);
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        if (documents == null) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+        }
+        if (documents.isEmpty()) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+        }
+        String modelName = configParams.get(Constants.EF_PARAMS_MODEL).toString();
+        BedrockRuntimeClient client = getClient();
+        try {
+            List<Embedding> results = new ArrayList<Embedding>();
+            for (String doc : documents) {
+                JsonObject requestBody = new JsonObject();
+                requestBody.addProperty("inputText", doc);
+                requestBody.addProperty("dimensions", 1024);
+                requestBody.addProperty("normalize", true);
+
+                InvokeModelRequest request = InvokeModelRequest.builder()
+                        .modelId(modelName)
+                        .body(SdkBytes.fromString(requestBody.toString(), StandardCharsets.UTF_8))
+                        .contentType("application/json")
+                        .accept("application/json")
+                        .build();
+
+                InvokeModelResponse response = client.invokeModel(request);
+                String responseJson = response.body().asUtf8String();
+                JsonObject responseObj = JsonParser.parseString(responseJson).getAsJsonObject();
+                JsonArray embeddingArray = responseObj.getAsJsonArray("embedding");
+
+                float[] floatArray = new float[embeddingArray.size()];
+                for (int i = 0; i < embeddingArray.size(); i++) {
+                    floatArray[i] = embeddingArray.get(i).getAsFloat();
+                }
+                results.add(new Embedding(floatArray));
+            }
+            if (results.size() != documents.size()) {
+                throw new ChromaException(
+                        "Bedrock embedding failed (model: " + modelName + "): "
+                                + "expected " + documents.size() + " embeddings, got " + results.size()
+                );
+            }
+            return results;
+        } catch (ChromaException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new EFException("Bedrock embedding failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        return embedDocuments(Arrays.asList(documents));
+    }
+
+    /**
+     * Inner WithParam subclass for configuring the AWS region.
+     */
+    private static class WithRegion extends WithParam {
+        private final String region;
+
+        WithRegion(String region) {
+            this.region = region;
+        }
+
+        @Override
+        public void apply(Map<String, Object> params) {
+            params.put(CONFIG_KEY_REGION, region);
+        }
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
@@ -105,28 +105,37 @@ public class BedrockEmbeddingFunction implements EmbeddingFunction {
 
     @Override
     public Embedding embedQuery(String query) throws EFException {
+        String modelName = modelName();
         if (query == null) {
             throw new ChromaException(
-                    "Bedrock embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+                    "Bedrock embedding failed (model: " + modelName + "): query must not be null");
         }
         return embedDocuments(Collections.singletonList(query)).get(0);
     }
 
     @Override
     public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        String modelName = modelName();
         if (documents == null) {
             throw new ChromaException(
-                    "Bedrock embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+                    "Bedrock embedding failed (model: " + modelName + "): documents must not be null");
         }
         if (documents.isEmpty()) {
             throw new ChromaException(
-                    "Bedrock embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+                    "Bedrock embedding failed (model: " + modelName + "): documents must not be empty");
         }
-        String modelName = configParams.get(Constants.EF_PARAMS_MODEL).toString();
+        for (int docIndex = 0; docIndex < documents.size(); docIndex++) {
+            if (documents.get(docIndex) == null) {
+                throw new ChromaException(
+                        "Bedrock embedding failed (model: " + modelName
+                                + "): document at index " + docIndex + " must not be null");
+            }
+        }
         BedrockRuntimeClient client = getClient();
         try {
             List<Embedding> results = new ArrayList<Embedding>();
-            for (String doc : documents) {
+            for (int docIndex = 0; docIndex < documents.size(); docIndex++) {
+                String doc = documents.get(docIndex);
                 JsonObject requestBody = new JsonObject();
                 requestBody.addProperty("inputText", doc);
                 requestBody.addProperty("dimensions", 1024);
@@ -167,6 +176,11 @@ public class BedrockEmbeddingFunction implements EmbeddingFunction {
     @Override
     public List<Embedding> embedDocuments(String[] documents) throws EFException {
         return embedDocuments(Arrays.asList(documents));
+    }
+
+    private String modelName() {
+        Object model = configParams.get(Constants.EF_PARAMS_MODEL);
+        return model != null ? model.toString() : DEFAULT_MODEL_NAME;
     }
 
     /**

--- a/src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bedrock/BedrockEmbeddingFunction.java
@@ -1,7 +1,7 @@
 package tech.amikos.chromadb.embeddings.bedrock;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import software.amazon.awssdk.core.SdkBytes;
@@ -42,7 +42,6 @@ public class BedrockEmbeddingFunction implements EmbeddingFunction {
 
     private final Map<String, Object> configParams = new HashMap<String, Object>();
     private volatile BedrockRuntimeClient bedrockClient;
-    private final Gson gson = new Gson();
 
     private static final List<WithParam> defaults = Arrays.asList(
             WithParam.defaultModel(DEFAULT_MODEL_NAME)
@@ -85,18 +84,26 @@ public class BedrockEmbeddingFunction implements EmbeddingFunction {
         }
     }
 
-    private BedrockRuntimeClient getClient() {
+    private BedrockRuntimeClient getClient() throws EFException {
         if (bedrockClient == null) {
             synchronized (this) {
                 if (bedrockClient == null) {
-                    String regionStr = configParams.containsKey(CONFIG_KEY_REGION)
-                            ? configParams.get(CONFIG_KEY_REGION).toString()
-                            : System.getenv(AWS_REGION_ENV) != null
-                            ? System.getenv(AWS_REGION_ENV)
-                            : DEFAULT_REGION;
-                    bedrockClient = BedrockRuntimeClient.builder()
-                            .region(Region.of(regionStr))
-                            .build();
+                    String regionStr = resolveRegion();
+                    if (regionStr == null || regionStr.trim().isEmpty()) {
+                        throw new EFException(
+                                "Failed to initialize Bedrock client: AWS region must not be null or blank");
+                    }
+                    try {
+                        bedrockClient = BedrockRuntimeClient.builder()
+                                .region(Region.of(regionStr))
+                                .build();
+                    } catch (RuntimeException e) {
+                        throw new EFException(
+                                "Failed to initialize Bedrock client for region '" + regionStr + "': "
+                                        + e.getMessage(),
+                                e
+                        );
+                    }
                 }
             }
         }
@@ -149,15 +156,7 @@ public class BedrockEmbeddingFunction implements EmbeddingFunction {
                         .build();
 
                 InvokeModelResponse response = client.invokeModel(request);
-                String responseJson = response.body().asUtf8String();
-                JsonObject responseObj = JsonParser.parseString(responseJson).getAsJsonObject();
-                JsonArray embeddingArray = responseObj.getAsJsonArray("embedding");
-
-                float[] floatArray = new float[embeddingArray.size()];
-                for (int i = 0; i < embeddingArray.size(); i++) {
-                    floatArray[i] = embeddingArray.get(i).getAsFloat();
-                }
-                results.add(new Embedding(floatArray));
+                results.add(toEmbedding(response, modelName));
             }
             if (results.size() != documents.size()) {
                 throw new ChromaException(
@@ -175,12 +174,90 @@ public class BedrockEmbeddingFunction implements EmbeddingFunction {
 
     @Override
     public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        if (documents == null) {
+            return embedDocuments((List<String>) null);
+        }
         return embedDocuments(Arrays.asList(documents));
     }
 
     private String modelName() {
         Object model = configParams.get(Constants.EF_PARAMS_MODEL);
         return model != null ? model.toString() : DEFAULT_MODEL_NAME;
+    }
+
+    private String resolveRegion() {
+        if (configParams.containsKey(CONFIG_KEY_REGION)) {
+            Object configuredRegion = configParams.get(CONFIG_KEY_REGION);
+            return configuredRegion != null ? configuredRegion.toString() : null;
+        }
+        String envRegion = System.getenv(AWS_REGION_ENV);
+        return envRegion != null ? envRegion : DEFAULT_REGION;
+    }
+
+    private Embedding toEmbedding(InvokeModelResponse response, String modelName) {
+        if (response == null || response.body() == null) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + modelName + "): response body was empty");
+        }
+        String responseJson = response.body().asUtf8String();
+        if (responseJson == null || responseJson.trim().isEmpty()) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + modelName + "): response body was empty");
+        }
+
+        JsonObject responseObj = parseResponseObject(responseJson, modelName);
+        JsonElement embeddingElement = responseObj.get("embedding");
+        if (embeddingElement == null || embeddingElement.isJsonNull()) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + modelName + "): response missing embedding array");
+        }
+        if (!embeddingElement.isJsonArray()) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + modelName + "): response embedding field must be an array");
+        }
+        JsonArray embeddingArray = embeddingElement.getAsJsonArray();
+        if (embeddingArray.size() == 0) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + modelName + "): response embedding array was empty");
+        }
+
+        float[] floatArray = new float[embeddingArray.size()];
+        for (int i = 0; i < embeddingArray.size(); i++) {
+            JsonElement value = embeddingArray.get(i);
+            if (value == null || value.isJsonNull()) {
+                throw new ChromaException(
+                        "Bedrock embedding failed (model: " + modelName
+                                + "): response embedding value at index " + i + " was null");
+            }
+            try {
+                floatArray[i] = value.getAsFloat();
+            } catch (RuntimeException e) {
+                throw new ChromaException(
+                        "Bedrock embedding failed (model: " + modelName
+                                + "): response embedding value at index " + i + " was not numeric",
+                        e
+                );
+            }
+        }
+        return new Embedding(floatArray);
+    }
+
+    private JsonObject parseResponseObject(String responseJson, String modelName) {
+        try {
+            JsonElement parsed = JsonParser.parseString(responseJson);
+            if (parsed == null || !parsed.isJsonObject()) {
+                throw new ChromaException(
+                        "Bedrock embedding failed (model: " + modelName + "): response must be a JSON object");
+            }
+            return parsed.getAsJsonObject();
+        } catch (ChromaException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new ChromaException(
+                    "Bedrock embedding failed (model: " + modelName + "): response could not be parsed",
+                    e
+            );
+        }
     }
 
     /**

--- a/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
@@ -1,0 +1,119 @@
+package tech.amikos.chromadb.embeddings.bm25;
+
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.SparseEmbeddingFunction;
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * BM25 sparse embedding function that produces {@link SparseVector} output.
+ *
+ * <p>Uses the same tokenization pipeline as the Go and Python Chroma clients
+ * for cross-client index compatibility: lowercase, regex split, stop word filter,
+ * Snowball English stemmer, Murmur3 hashing.</p>
+ *
+ * <p>Default BM25 parameters: K=1.2, B=0.75, avgDocLen=256.</p>
+ */
+public class BM25EmbeddingFunction implements SparseEmbeddingFunction {
+
+    // Use Charset.forName for Java 8 compatibility (StandardCharsets requires API level check)
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    static final float K = 1.2f;
+    static final float B = 0.75f;
+    static final float DEFAULT_AVG_DOC_LEN = 256.0f;
+
+    private final BM25Tokenizer tokenizer;
+    private final float avgDocLen;
+
+    /**
+     * Creates a BM25 embedding function with default parameters.
+     */
+    public BM25EmbeddingFunction() {
+        this(new BM25Tokenizer(), DEFAULT_AVG_DOC_LEN);
+    }
+
+    /**
+     * Creates a BM25 embedding function with custom tokenizer and average document length.
+     *
+     * @param tokenizer the tokenizer pipeline to use
+     * @param avgDocLen the expected average document length for BM25 normalization
+     */
+    public BM25EmbeddingFunction(BM25Tokenizer tokenizer, float avgDocLen) {
+        this.tokenizer = tokenizer;
+        this.avgDocLen = avgDocLen;
+    }
+
+    @Override
+    public SparseVector embedQuery(String query) throws EFException {
+        return embedSingle(query);
+    }
+
+    @Override
+    public List<SparseVector> embedDocuments(List<String> documents) throws EFException {
+        List<SparseVector> results = new ArrayList<>();
+        for (String doc : documents) {
+            results.add(embedSingle(doc));
+        }
+        return results;
+    }
+
+    private SparseVector embedSingle(String text) {
+        if (text == null || text.isEmpty()) {
+            return SparseVector.of(new int[0], new float[0]);
+        }
+
+        List<String> tokens = tokenizer.tokenize(text);
+        if (tokens.isEmpty()) {
+            return SparseVector.of(new int[0], new float[0]);
+        }
+
+        int docLen = tokens.size();
+
+        // Count term frequencies
+        Map<String, Integer> tf = new LinkedHashMap<>();
+        for (String token : tokens) {
+            Integer count = tf.get(token);
+            tf.put(token, count == null ? 1 : count + 1);
+        }
+
+        // Compute BM25 scores per hashed index
+        // Use TreeMap to get sorted indices automatically
+        TreeMap<Integer, Float> scoreMap = new TreeMap<>();
+        for (Map.Entry<String, Integer> entry : tf.entrySet()) {
+            String token = entry.getKey();
+            int tfVal = entry.getValue();
+
+            float score = (tfVal * (K + 1)) / (tfVal + K * (1 - B + B * docLen / avgDocLen));
+
+            int idx = Murmur3.hash32(token.getBytes(UTF_8), 0);
+
+            // Accumulate scores per index (collision: sum)
+            Float existing = scoreMap.get(idx);
+            if (existing != null) {
+                scoreMap.put(idx, existing + score);
+            } else {
+                scoreMap.put(idx, score);
+            }
+        }
+
+        // Build sorted arrays
+        int[] indices = new int[scoreMap.size()];
+        float[] values = new float[scoreMap.size()];
+        int i = 0;
+        for (Map.Entry<Integer, Float> entry : scoreMap.entrySet()) {
+            indices[i] = entry.getKey();
+            values[i] = entry.getValue();
+            i++;
+        }
+
+        return SparseVector.of(indices, values);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
@@ -73,14 +73,21 @@ public class BM25EmbeddingFunction implements SparseEmbeddingFunction {
         }
 
         List<SparseVector> results = new ArrayList<SparseVector>(documents.size());
-        for (String doc : documents) {
+        for (int i = 0; i < documents.size(); i++) {
+            String doc = documents.get(i);
+            if (doc == null) {
+                throw new ChromaException("BM25 embedding failed: document at index " + i + " must not be null");
+            }
             results.add(embedSingle(doc));
         }
         return results;
     }
 
     private SparseVector embedSingle(String text) {
-        if (text == null || text.isEmpty()) {
+        if (text == null) {
+            throw new ChromaException("BM25 embedding failed: text must not be null");
+        }
+        if (text.isEmpty()) {
             return SparseVector.of(new int[0], new float[0]);
         }
 

--- a/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25EmbeddingFunction.java
@@ -2,6 +2,7 @@ package tech.amikos.chromadb.embeddings.bm25;
 
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.embeddings.SparseEmbeddingFunction;
+import tech.amikos.chromadb.v2.ChromaException;
 import tech.amikos.chromadb.v2.SparseVector;
 
 import java.nio.charset.Charset;
@@ -47,18 +48,31 @@ public class BM25EmbeddingFunction implements SparseEmbeddingFunction {
      * @param avgDocLen the expected average document length for BM25 normalization
      */
     public BM25EmbeddingFunction(BM25Tokenizer tokenizer, float avgDocLen) {
+        if (tokenizer == null) {
+            throw new IllegalArgumentException("tokenizer must not be null");
+        }
         this.tokenizer = tokenizer;
         this.avgDocLen = avgDocLen;
     }
 
     @Override
     public SparseVector embedQuery(String query) throws EFException {
+        if (query == null) {
+            throw new ChromaException("BM25 embedding failed: query must not be null");
+        }
         return embedSingle(query);
     }
 
     @Override
     public List<SparseVector> embedDocuments(List<String> documents) throws EFException {
-        List<SparseVector> results = new ArrayList<>();
+        if (documents == null) {
+            throw new ChromaException("BM25 embedding failed: documents must not be null");
+        }
+        if (documents.isEmpty()) {
+            throw new ChromaException("BM25 embedding failed: documents must not be empty");
+        }
+
+        List<SparseVector> results = new ArrayList<SparseVector>(documents.size());
         for (String doc : documents) {
             results.add(embedSingle(doc));
         }

--- a/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25StopWords.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25StopWords.java
@@ -1,0 +1,42 @@
+package tech.amikos.chromadb.embeddings.bm25;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Default stop words for BM25 tokenization, matching Go client's
+ * {@code DEFAULT_CHROMA_BM25_STOPWORDS} (174 NLTK English stop words).
+ */
+public final class BM25StopWords {
+
+    /**
+     * Unmodifiable set of 174 NLTK English stop words matching the Go client.
+     */
+    public static final Set<String> DEFAULT = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "a", "about", "above", "after", "again", "against", "ain", "all", "am", "an",
+            "and", "any", "are", "aren", "aren't", "as", "at", "be", "because", "been",
+            "before", "being", "below", "between", "both", "but", "by", "can", "couldn",
+            "couldn't", "d", "did", "didn", "didn't", "do", "does", "doesn", "doesn't",
+            "doing", "don", "don't", "down", "during", "each", "few", "for", "from",
+            "further", "had", "hadn", "hadn't", "has", "hasn", "hasn't", "have", "haven",
+            "haven't", "having", "he", "her", "here", "hers", "herself", "him", "himself",
+            "his", "how", "i", "if", "in", "into", "is", "isn", "isn't", "it", "it's",
+            "its", "itself", "just", "ll", "m", "ma", "me", "mightn", "mightn't", "more",
+            "most", "mustn", "mustn't", "my", "myself", "needn", "needn't", "no", "nor",
+            "not", "now", "o", "of", "off", "on", "once", "only", "or", "other", "our",
+            "ours", "ourselves", "out", "over", "own", "re", "s", "same", "shan", "shan't",
+            "she", "she's", "should", "should've", "shouldn", "shouldn't", "so", "some",
+            "such", "t", "than", "that", "that'll", "the", "their", "theirs", "them",
+            "themselves", "then", "there", "these", "they", "this", "those", "through",
+            "to", "too", "under", "until", "up", "ve", "very", "was", "wasn", "wasn't",
+            "we", "were", "weren", "weren't", "what", "when", "where", "which", "while",
+            "who", "whom", "why", "will", "with", "won", "won't", "wouldn", "wouldn't",
+            "y", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself",
+            "yourselves"
+    )));
+
+    private BM25StopWords() {
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java
@@ -16,7 +16,6 @@ public class BM25Tokenizer {
 
     private final Set<String> stopWords;
     private final int tokenMaxLength;
-    private final englishStemmer stemmer;
 
     /**
      * Creates a tokenizer with default stop words and token max length of 100.
@@ -34,7 +33,6 @@ public class BM25Tokenizer {
     public BM25Tokenizer(Set<String> stopWords, int tokenMaxLength) {
         this.stopWords = stopWords;
         this.tokenMaxLength = tokenMaxLength;
-        this.stemmer = new englishStemmer();
     }
 
     /**
@@ -62,7 +60,8 @@ public class BM25Tokenizer {
         String[] parts = trimmed.split("\\s+");
 
         // 4-6. Filter stop words, max length, and stem
-        List<String> result = new ArrayList<>();
+        englishStemmer stemmer = new englishStemmer();
+        List<String> result = new ArrayList<String>(parts.length);
         for (String token : parts) {
             if (token.isEmpty()) {
                 continue;

--- a/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bm25/BM25Tokenizer.java
@@ -1,0 +1,83 @@
+package tech.amikos.chromadb.embeddings.bm25;
+
+import org.tartarus.snowball.ext.englishStemmer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * BM25-compatible tokenizer pipeline matching the Go client:
+ * lowercase, regex split on non-alphanumeric, stop word filter, max-length filter, Snowball stem.
+ */
+public class BM25Tokenizer {
+
+    private final Set<String> stopWords;
+    private final int tokenMaxLength;
+    private final englishStemmer stemmer;
+
+    /**
+     * Creates a tokenizer with default stop words and token max length of 100.
+     */
+    public BM25Tokenizer() {
+        this(BM25StopWords.DEFAULT, 100);
+    }
+
+    /**
+     * Creates a tokenizer with custom stop words and token max length.
+     *
+     * @param stopWords      set of stop words to filter
+     * @param tokenMaxLength maximum allowed token length
+     */
+    public BM25Tokenizer(Set<String> stopWords, int tokenMaxLength) {
+        this.stopWords = stopWords;
+        this.tokenMaxLength = tokenMaxLength;
+        this.stemmer = new englishStemmer();
+    }
+
+    /**
+     * Tokenizes text through the BM25 pipeline: lowercase, split, filter, stem.
+     *
+     * @param text the input text
+     * @return list of stemmed tokens (not deduplicated -- TF counting happens in BM25)
+     */
+    public List<String> tokenize(String text) {
+        if (text == null || text.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 1. Lowercase
+        String lower = text.toLowerCase(Locale.ROOT);
+
+        // 2. Replace non-alphanumeric with space
+        String cleaned = lower.replaceAll("[^a-zA-Z0-9]+", " ");
+
+        // 3. Split on whitespace
+        String trimmed = cleaned.trim();
+        if (trimmed.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String[] parts = trimmed.split("\\s+");
+
+        // 4-6. Filter stop words, max length, and stem
+        List<String> result = new ArrayList<>();
+        for (String token : parts) {
+            if (token.isEmpty()) {
+                continue;
+            }
+            if (stopWords.contains(token)) {
+                continue;
+            }
+            if (token.length() > tokenMaxLength) {
+                continue;
+            }
+            // Stem
+            stemmer.setCurrent(token);
+            stemmer.stem();
+            result.add(stemmer.getCurrent());
+        }
+        return result;
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/bm25/Murmur3.java
@@ -1,0 +1,84 @@
+package tech.amikos.chromadb.embeddings.bm25;
+
+/**
+ * Murmur3 x86 32-bit hash implementation.
+ *
+ * <p>This is an inline implementation (not Guava) to avoid pulling in a large dependency.
+ * It matches the output of Python's {@code mmh3.hash(text, seed, signed=True)} and
+ * Go's {@code github.com/spaolacci/murmur3}.</p>
+ */
+public final class Murmur3 {
+
+    private static final int C1 = 0xcc9e2d51;
+    private static final int C2 = 0x1b873593;
+
+    private Murmur3() {
+    }
+
+    /**
+     * Computes Murmur3 x86 32-bit hash of the given data with the specified seed.
+     *
+     * @param data the bytes to hash
+     * @param seed the hash seed
+     * @return signed 32-bit hash value
+     */
+    public static int hash32(byte[] data, int seed) {
+        int h1 = seed;
+        int len = data.length;
+        int nblocks = len / 4;
+
+        // body: process 4-byte blocks
+        for (int i = 0; i < nblocks; i++) {
+            int k1 = getBlock32(data, i * 4);
+            k1 *= C1;
+            k1 = Integer.rotateLeft(k1, 15);
+            k1 *= C2;
+
+            h1 ^= k1;
+            h1 = Integer.rotateLeft(h1, 13);
+            h1 = h1 * 5 + 0xe6546b64;
+        }
+
+        // tail: handle remaining bytes
+        int tail = nblocks * 4;
+        int k1 = 0;
+        switch (len & 3) {
+            case 3:
+                k1 ^= (data[tail + 2] & 0xff) << 16;
+                // fall through
+            case 2:
+                k1 ^= (data[tail + 1] & 0xff) << 8;
+                // fall through
+            case 1:
+                k1 ^= (data[tail] & 0xff);
+                k1 *= C1;
+                k1 = Integer.rotateLeft(k1, 15);
+                k1 *= C2;
+                h1 ^= k1;
+                break;
+            default:
+                break;
+        }
+
+        // finalization
+        h1 ^= len;
+        h1 = fmix32(h1);
+        return h1;
+    }
+
+    private static int fmix32(int h) {
+        h ^= h >>> 16;
+        h *= 0x85ebca6b;
+        h ^= h >>> 13;
+        h *= 0xc2b2ae35;
+        h ^= h >>> 16;
+        return h;
+    }
+
+    private static int getBlock32(byte[] data, int offset) {
+        return (data[offset] & 0xff)
+                | ((data[offset + 1] & 0xff) << 8)
+                | ((data[offset + 2] & 0xff) << 16)
+                | ((data[offset + 3] & 0xff) << 24);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
@@ -1,0 +1,144 @@
+package tech.amikos.chromadb.embeddings.chromacloudsplade;
+
+import com.google.gson.Gson;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import tech.amikos.chromadb.Constants;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.SparseEmbeddingFunction;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.v2.ChromaException;
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static tech.amikos.chromadb.Constants.JSON;
+
+/**
+ * Sparse embedding function that calls the Chroma Cloud Splade API.
+ *
+ * <p>Implements {@link SparseEmbeddingFunction} and produces {@link SparseVector}
+ * representations via the remote Chroma Cloud sparse embedding endpoint.</p>
+ */
+public class ChromaCloudSpladeEmbeddingFunction implements SparseEmbeddingFunction {
+
+    static String DEFAULT_BASE_API = "https://api.trychroma.com/api/v2/embed/splade";
+    public static final String DEFAULT_MODEL_NAME = "splade";
+    public static final String CHROMA_API_KEY_ENV = "CHROMA_API_KEY";
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final Gson gson = new Gson();
+    private final Map<String, Object> configParams = new HashMap<String, Object>();
+
+    private static final List<WithParam> defaults = Arrays.asList(
+            WithParam.baseAPI(DEFAULT_BASE_API),
+            WithParam.defaultModel(DEFAULT_MODEL_NAME)
+    );
+
+    /**
+     * Creates a ChromaCloudSpladeEmbeddingFunction using the CHROMA_API_KEY environment variable.
+     *
+     * @throws EFException if the environment variable is not set
+     */
+    public ChromaCloudSpladeEmbeddingFunction() throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        WithParam.apiKeyFromEnv(CHROMA_API_KEY_ENV).apply(this.configParams);
+    }
+
+    /**
+     * Creates a ChromaCloudSpladeEmbeddingFunction with the given parameters.
+     *
+     * @param params configuration parameters (apiKey, model, baseAPI, etc.)
+     * @throws EFException if parameter application fails
+     */
+    public ChromaCloudSpladeEmbeddingFunction(WithParam... params) throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        for (WithParam param : params) {
+            param.apply(this.configParams);
+        }
+    }
+
+    private CreateSparseEmbeddingResponse callApi(CreateSparseEmbeddingRequest req) throws EFException {
+        String baseApi = configParams.get(Constants.EF_PARAMS_BASE_API).toString();
+        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+
+        Request request = new Request.Builder()
+                .url(baseApi)
+                .post(RequestBody.create(req.toJson(), JSON))
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Authorization", "Bearer " + (apiKey != null ? apiKey.toString() : ""))
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed (model: "
+                                + configParams.get(Constants.EF_PARAMS_MODEL) + "): "
+                                + response.code() + " " + response.message()
+                );
+            }
+            String responseData = response.body().string();
+            return gson.fromJson(responseData, CreateSparseEmbeddingResponse.class);
+        } catch (ChromaException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new EFException("Chroma Cloud Splade embedding failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public SparseVector embedQuery(String query) throws EFException {
+        if (query == null) {
+            throw new ChromaException(
+                    "Chroma Cloud Splade embedding failed (model: "
+                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+        }
+        CreateSparseEmbeddingRequest req = new CreateSparseEmbeddingRequest()
+                .model(configParams.get(Constants.EF_PARAMS_MODEL).toString())
+                .texts(Collections.singletonList(query));
+        CreateSparseEmbeddingResponse response = callApi(req);
+        List<SparseVector> vectors = response.toSparseVectors();
+        if (vectors.isEmpty()) {
+            throw new ChromaException("Chroma Cloud Splade returned no results");
+        }
+        return vectors.get(0);
+    }
+
+    @Override
+    public List<SparseVector> embedDocuments(List<String> documents) throws EFException {
+        if (documents == null) {
+            throw new ChromaException(
+                    "Chroma Cloud Splade embedding failed (model: "
+                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+        }
+        if (documents.isEmpty()) {
+            throw new ChromaException(
+                    "Chroma Cloud Splade embedding failed (model: "
+                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+        }
+        CreateSparseEmbeddingRequest req = new CreateSparseEmbeddingRequest()
+                .model(configParams.get(Constants.EF_PARAMS_MODEL).toString())
+                .texts(documents);
+        CreateSparseEmbeddingResponse response = callApi(req);
+        List<SparseVector> result = response.toSparseVectors();
+        if (result.size() != documents.size()) {
+            throw new ChromaException(
+                    "Chroma Cloud Splade embedding failed (model: "
+                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): "
+                            + "expected " + documents.size() + " embeddings, got " + result.size()
+            );
+        }
+        return result;
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
@@ -114,18 +114,20 @@ public class ChromaCloudSpladeEmbeddingFunction implements SparseEmbeddingFuncti
             throw e;
         } catch (IOException e) {
             throw new EFException("Chroma Cloud Splade embedding failed: " + e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new ChromaException("Chroma Cloud Splade embedding failed (model: " + modelName + "): " + e.getMessage(), e);
         }
     }
 
     @Override
     public SparseVector embedQuery(String query) throws EFException {
+        String modelName = modelName();
         if (query == null) {
             throw new ChromaException(
-                    "Chroma Cloud Splade embedding failed (model: "
-                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+                    "Chroma Cloud Splade embedding failed (model: " + modelName + "): query must not be null");
         }
         CreateSparseEmbeddingRequest req = new CreateSparseEmbeddingRequest()
-                .model(configParams.get(Constants.EF_PARAMS_MODEL).toString())
+                .model(modelName)
                 .texts(Collections.singletonList(query));
         CreateSparseEmbeddingResponse response = callApi(req);
         List<SparseVector> vectors = response.toSparseVectors();
@@ -137,25 +139,23 @@ public class ChromaCloudSpladeEmbeddingFunction implements SparseEmbeddingFuncti
 
     @Override
     public List<SparseVector> embedDocuments(List<String> documents) throws EFException {
+        String modelName = modelName();
         if (documents == null) {
             throw new ChromaException(
-                    "Chroma Cloud Splade embedding failed (model: "
-                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+                    "Chroma Cloud Splade embedding failed (model: " + modelName + "): documents must not be null");
         }
         if (documents.isEmpty()) {
             throw new ChromaException(
-                    "Chroma Cloud Splade embedding failed (model: "
-                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+                    "Chroma Cloud Splade embedding failed (model: " + modelName + "): documents must not be empty");
         }
         CreateSparseEmbeddingRequest req = new CreateSparseEmbeddingRequest()
-                .model(configParams.get(Constants.EF_PARAMS_MODEL).toString())
+                .model(modelName)
                 .texts(documents);
         CreateSparseEmbeddingResponse response = callApi(req);
         List<SparseVector> result = response.toSparseVectors();
         if (result.size() != documents.size()) {
             throw new ChromaException(
-                    "Chroma Cloud Splade embedding failed (model: "
-                            + configParams.get(Constants.EF_PARAMS_MODEL) + "): "
+                    "Chroma Cloud Splade embedding failed (model: " + modelName + "): "
                             + "expected " + documents.size() + " embeddings, got " + result.size()
             );
         }

--- a/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/ChromaCloudSpladeEmbeddingFunction.java
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import tech.amikos.chromadb.Constants;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.embeddings.SparseEmbeddingFunction;
@@ -71,25 +72,44 @@ public class ChromaCloudSpladeEmbeddingFunction implements SparseEmbeddingFuncti
 
     private CreateSparseEmbeddingResponse callApi(CreateSparseEmbeddingRequest req) throws EFException {
         String baseApi = configParams.get(Constants.EF_PARAMS_BASE_API).toString();
-        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+        String modelName = modelName();
+        String apiKey = requireApiKey(modelName);
 
         Request request = new Request.Builder()
                 .url(baseApi)
                 .post(RequestBody.create(req.toJson(), JSON))
                 .addHeader("Accept", "application/json")
                 .addHeader("Content-Type", "application/json")
-                .addHeader("Authorization", "Bearer " + (apiKey != null ? apiKey.toString() : ""))
+                .addHeader("Authorization", "Bearer " + apiKey)
                 .build();
         try (Response response = client.newCall(request).execute()) {
+            ResponseBody responseBody = response.body();
             if (!response.isSuccessful()) {
+                String body = responseBody != null ? responseBody.string() : "";
                 throw new ChromaException(
-                        "Chroma Cloud Splade embedding failed (model: "
-                                + configParams.get(Constants.EF_PARAMS_MODEL) + "): "
+                        "Chroma Cloud Splade embedding failed (model: " + modelName + "): "
                                 + response.code() + " " + response.message()
+                                + (body.isEmpty() ? "" : " - " + body)
                 );
             }
-            String responseData = response.body().string();
-            return gson.fromJson(responseData, CreateSparseEmbeddingResponse.class);
+            if (responseBody == null) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed (model: " + modelName + "): response body was empty"
+                );
+            }
+            String responseData = responseBody.string();
+            if (responseData.trim().isEmpty()) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed (model: " + modelName + "): response body was empty"
+                );
+            }
+            CreateSparseEmbeddingResponse parsed = gson.fromJson(responseData, CreateSparseEmbeddingResponse.class);
+            if (parsed == null) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed (model: " + modelName + "): response could not be parsed"
+                );
+            }
+            return parsed;
         } catch (ChromaException e) {
             throw e;
         } catch (IOException e) {
@@ -140,5 +160,20 @@ public class ChromaCloudSpladeEmbeddingFunction implements SparseEmbeddingFuncti
             );
         }
         return result;
+    }
+
+    private String modelName() {
+        Object model = configParams.get(Constants.EF_PARAMS_MODEL);
+        return model != null ? model.toString() : DEFAULT_MODEL_NAME;
+    }
+
+    private String requireApiKey(String modelName) {
+        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+        String normalized = apiKey == null ? null : apiKey.toString().trim();
+        if (normalized == null || normalized.isEmpty()) {
+            throw new ChromaException(
+                    "Chroma Cloud Splade embedding failed (model: " + modelName + "): API key must not be null or empty");
+        }
+        return normalized;
     }
 }

--- a/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingRequest.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingRequest.java
@@ -1,0 +1,39 @@
+package tech.amikos.chromadb.embeddings.chromacloudsplade;
+
+import com.google.gson.Gson;
+import okhttp3.MediaType;
+
+import java.util.List;
+
+/**
+ * Request DTO for the Chroma Cloud Splade sparse embedding API.
+ */
+public class CreateSparseEmbeddingRequest {
+
+    private String model;
+    private List<String> texts;
+
+    public CreateSparseEmbeddingRequest model(String model) {
+        this.model = model;
+        return this;
+    }
+
+    public CreateSparseEmbeddingRequest texts(List<String> texts) {
+        this.texts = texts;
+        return this;
+    }
+
+    /**
+     * Serializes this request to a JSON MediaType body.
+     */
+    public okhttp3.MediaType json() {
+        return MediaType.parse("application/json; charset=utf-8");
+    }
+
+    /**
+     * Returns the JSON string representation of this request.
+     */
+    public String toJson() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java
@@ -1,0 +1,54 @@
+package tech.amikos.chromadb.embeddings.chromacloudsplade;
+
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response DTO for the Chroma Cloud Splade sparse embedding API.
+ */
+public class CreateSparseEmbeddingResponse {
+
+    private List<SparseResult> results;
+
+    /**
+     * A single sparse embedding result from the API.
+     */
+    public static class SparseResult {
+        private List<Integer> indices;
+        private List<Float> values;
+
+        public List<Integer> getIndices() {
+            return indices;
+        }
+
+        public List<Float> getValues() {
+            return values;
+        }
+    }
+
+    public List<SparseResult> getResults() {
+        return results;
+    }
+
+    /**
+     * Converts the API response into a list of {@link SparseVector} instances.
+     */
+    public List<SparseVector> toSparseVectors() {
+        List<SparseVector> vectors = new ArrayList<>();
+        if (results == null) {
+            return vectors;
+        }
+        for (SparseResult r : results) {
+            int[] idx = new int[r.indices.size()];
+            float[] vals = new float[r.values.size()];
+            for (int i = 0; i < r.indices.size(); i++) {
+                idx[i] = r.indices.get(i);
+                vals[i] = r.values.get(i);
+            }
+            vectors.add(SparseVector.of(idx, vals));
+        }
+        return vectors;
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/chromacloudsplade/CreateSparseEmbeddingResponse.java
@@ -1,5 +1,6 @@
 package tech.amikos.chromadb.embeddings.chromacloudsplade;
 
+import tech.amikos.chromadb.v2.ChromaException;
 import tech.amikos.chromadb.v2.SparseVector;
 
 import java.util.ArrayList;
@@ -40,12 +41,44 @@ public class CreateSparseEmbeddingResponse {
         if (results == null) {
             return vectors;
         }
-        for (SparseResult r : results) {
+        for (int resultIndex = 0; resultIndex < results.size(); resultIndex++) {
+            SparseResult r = results.get(resultIndex);
+            if (r == null) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed: result at index " + resultIndex + " was null");
+            }
+            if (r.indices == null) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed: result at index " + resultIndex
+                                + " has no indices");
+            }
+            if (r.values == null) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed: result at index " + resultIndex
+                                + " has no values");
+            }
+            if (r.indices.size() != r.values.size()) {
+                throw new ChromaException(
+                        "Chroma Cloud Splade embedding failed: result at index " + resultIndex
+                                + " has mismatched indices and values sizes");
+            }
             int[] idx = new int[r.indices.size()];
             float[] vals = new float[r.values.size()];
             for (int i = 0; i < r.indices.size(); i++) {
-                idx[i] = r.indices.get(i);
-                vals[i] = r.values.get(i);
+                Integer index = r.indices.get(i);
+                Float value = r.values.get(i);
+                if (index == null) {
+                    throw new ChromaException(
+                            "Chroma Cloud Splade embedding failed: result at index " + resultIndex
+                                    + " has null index at position " + i);
+                }
+                if (value == null) {
+                    throw new ChromaException(
+                            "Chroma Cloud Splade embedding failed: result at index " + resultIndex
+                                    + " has null value at position " + i);
+                }
+                idx[i] = index;
+                vals[i] = value;
             }
             vectors.add(SparseVector.of(idx, vals));
         }

--- a/src/main/java/tech/amikos/chromadb/embeddings/content/BinarySource.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/content/BinarySource.java
@@ -1,0 +1,97 @@
+package tech.amikos.chromadb.embeddings.content;
+
+import java.util.Arrays;
+
+/**
+ * Immutable binary content source for multimodal embedding parts (images, audio, video).
+ *
+ * <p>Exactly one source field is set per instance. Use the static factory methods to create
+ * instances from URLs, file paths, base64-encoded strings, or raw byte arrays.</p>
+ */
+public final class BinarySource {
+
+    private final String url;
+    private final String filePath;
+    private final String base64Data;
+    private final byte[] data;
+
+    private BinarySource(String url, String filePath, String base64Data, byte[] data) {
+        this.url = url;
+        this.filePath = filePath;
+        this.base64Data = base64Data;
+        this.data = data;
+    }
+
+    public static BinarySource fromUrl(String url) {
+        if (url == null) {
+            throw new IllegalArgumentException("url must not be null");
+        }
+        return new BinarySource(url, null, null, null);
+    }
+
+    public static BinarySource fromFile(String path) {
+        if (path == null) {
+            throw new IllegalArgumentException("path must not be null");
+        }
+        return new BinarySource(null, path, null, null);
+    }
+
+    public static BinarySource fromBase64(String base64) {
+        if (base64 == null) {
+            throw new IllegalArgumentException("base64 must not be null");
+        }
+        return new BinarySource(null, null, base64, null);
+    }
+
+    public static BinarySource fromBytes(byte[] data) {
+        if (data == null) {
+            throw new IllegalArgumentException("data must not be null");
+        }
+        return new BinarySource(null, null, null, Arrays.copyOf(data, data.length));
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public String getBase64Data() {
+        return base64Data;
+    }
+
+    public byte[] getBytes() {
+        return data == null ? null : Arrays.copyOf(data, data.length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BinarySource)) return false;
+        BinarySource that = (BinarySource) o;
+        if (url != null ? !url.equals(that.url) : that.url != null) return false;
+        if (filePath != null ? !filePath.equals(that.filePath) : that.filePath != null) return false;
+        if (base64Data != null ? !base64Data.equals(that.base64Data) : that.base64Data != null) return false;
+        return Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = url != null ? url.hashCode() : 0;
+        result = 31 * result + (filePath != null ? filePath.hashCode() : 0);
+        result = 31 * result + (base64Data != null ? base64Data.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(data);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        if (url != null) return "BinarySource{url='" + url + "'}";
+        if (filePath != null) return "BinarySource{filePath='" + filePath + "'}";
+        if (base64Data != null) return "BinarySource{base64Data=<" + base64Data.length() + " chars>}";
+        if (data != null) return "BinarySource{data=<" + data.length + " bytes>}";
+        return "BinarySource{empty}";
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/content/Content.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/content/Content.java
@@ -1,0 +1,131 @@
+package tech.amikos.chromadb.embeddings.content;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable multimodal content value type for content-based embedding functions.
+ *
+ * <p>A {@code Content} contains one or more {@link Part} objects (text, image, audio, video)
+ * and an optional {@link Intent} hint for embedding providers that distinguish between
+ * document and query embeddings.</p>
+ *
+ * <p>Use {@link #text(String)} for simple text content, or {@link #builder()} for
+ * multi-part content with explicit intent.</p>
+ */
+public final class Content {
+
+    private final List<Part> parts;
+    private final Intent intent;
+
+    private Content(List<Part> parts, Intent intent) {
+        this.parts = Collections.unmodifiableList(new ArrayList<Part>(parts));
+        this.intent = intent;
+    }
+
+    /**
+     * Creates a text-only content with a single text part and no intent.
+     *
+     * @param text the text content; must not be null
+     * @return a new Content with a single text part
+     */
+    public static Content text(String text) {
+        if (text == null) {
+            throw new IllegalArgumentException("text must not be null");
+        }
+        return new Content(Collections.singletonList(Part.text(text)), null);
+    }
+
+    /**
+     * Returns a new builder for constructing multi-part content.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns an unmodifiable list of content parts.
+     */
+    public List<Part> getParts() {
+        return parts;
+    }
+
+    /**
+     * Returns the embedding intent hint, or {@code null} if not specified.
+     */
+    public Intent getIntent() {
+        return intent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Content)) return false;
+        Content content = (Content) o;
+        if (!parts.equals(content.parts)) return false;
+        return intent == content.intent;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = parts.hashCode();
+        result = 31 * result + (intent != null ? intent.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Content{parts=" + parts + ", intent=" + intent + '}';
+    }
+
+    /**
+     * Builder for constructing {@link Content} instances with multiple parts and optional intent.
+     */
+    public static final class Builder {
+
+        private final List<Part> parts = new ArrayList<Part>();
+        private Intent intent;
+
+        private Builder() {
+        }
+
+        /**
+         * Adds a part to this content.
+         *
+         * @param part the part to add; must not be null
+         * @return this builder
+         */
+        public Builder part(Part part) {
+            if (part == null) {
+                throw new IllegalArgumentException("part must not be null");
+            }
+            parts.add(part);
+            return this;
+        }
+
+        /**
+         * Sets the embedding intent hint.
+         *
+         * @param intent the intent; may be null
+         * @return this builder
+         */
+        public Builder intent(Intent intent) {
+            this.intent = intent;
+            return this;
+        }
+
+        /**
+         * Builds the content.
+         *
+         * @return a new Content instance
+         * @throws IllegalArgumentException if no parts have been added
+         */
+        public Content build() {
+            if (parts.isEmpty()) {
+                throw new IllegalArgumentException("Content must have at least one part");
+            }
+            return new Content(parts, intent);
+        }
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/content/Intent.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/content/Intent.java
@@ -1,0 +1,36 @@
+package tech.amikos.chromadb.embeddings.content;
+
+import java.util.Locale;
+
+/**
+ * Embedding intent hint for providers that distinguish between document and query embeddings.
+ */
+public enum Intent {
+    RETRIEVAL_DOCUMENT("retrieval_document"),
+    RETRIEVAL_QUERY("retrieval_query"),
+    CLASSIFICATION("classification"),
+    CLUSTERING("clustering");
+
+    private final String value;
+
+    Intent(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Intent fromValue(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("value must not be null");
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        for (Intent intent : values()) {
+            if (intent.value.equals(normalized)) {
+                return intent;
+            }
+        }
+        throw new IllegalArgumentException("Unknown intent: " + value);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/content/Modality.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/content/Modality.java
@@ -1,0 +1,36 @@
+package tech.amikos.chromadb.embeddings.content;
+
+import java.util.Locale;
+
+/**
+ * Content modality for multimodal embedding support.
+ */
+public enum Modality {
+    TEXT("text"),
+    IMAGE("image"),
+    AUDIO("audio"),
+    VIDEO("video");
+
+    private final String value;
+
+    Modality(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Modality fromValue(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("value must not be null");
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        for (Modality modality : values()) {
+            if (modality.value.equals(normalized)) {
+                return modality;
+            }
+        }
+        throw new IllegalArgumentException("Unknown modality: " + value);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/content/Part.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/content/Part.java
@@ -1,0 +1,87 @@
+package tech.amikos.chromadb.embeddings.content;
+
+/**
+ * A single part of a {@link Content} object, representing one modality (text, image, audio, video).
+ *
+ * <p>For text parts, {@link #getText()} returns the text and {@link #getSource()} is null.
+ * For binary parts (image, audio, video), {@link #getSource()} returns the binary source
+ * and {@link #getText()} is null.</p>
+ */
+public final class Part {
+
+    private final Modality modality;
+    private final String text;
+    private final BinarySource source;
+
+    private Part(Modality modality, String text, BinarySource source) {
+        this.modality = modality;
+        this.text = text;
+        this.source = source;
+    }
+
+    public static Part text(String text) {
+        if (text == null) {
+            throw new IllegalArgumentException("text must not be null");
+        }
+        return new Part(Modality.TEXT, text, null);
+    }
+
+    public static Part image(BinarySource source) {
+        if (source == null) {
+            throw new IllegalArgumentException("source must not be null");
+        }
+        return new Part(Modality.IMAGE, null, source);
+    }
+
+    public static Part audio(BinarySource source) {
+        if (source == null) {
+            throw new IllegalArgumentException("source must not be null");
+        }
+        return new Part(Modality.AUDIO, null, source);
+    }
+
+    public static Part video(BinarySource source) {
+        if (source == null) {
+            throw new IllegalArgumentException("source must not be null");
+        }
+        return new Part(Modality.VIDEO, null, source);
+    }
+
+    public Modality getModality() {
+        return modality;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public BinarySource getSource() {
+        return source;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Part)) return false;
+        Part part = (Part) o;
+        if (modality != part.modality) return false;
+        if (text != null ? !text.equals(part.text) : part.text != null) return false;
+        return source != null ? source.equals(part.source) : part.source == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = modality.hashCode();
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = 31 * result + (source != null ? source.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        if (modality == Modality.TEXT) {
+            return "Part{modality=TEXT, text='" + text + "'}";
+        }
+        return "Part{modality=" + modality + ", source=" + source + '}';
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
@@ -83,53 +83,43 @@ public class GeminiEmbeddingFunction implements EmbeddingFunction {
 
     @Override
     public Embedding embedQuery(String query) throws EFException {
+        String modelName = modelName();
         if (query == null) {
             throw new ChromaException(
-                    "Gemini embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+                    "Gemini embedding failed (model: " + modelName + "): query must not be null");
         }
         return embedDocuments(Collections.singletonList(query)).get(0);
     }
 
     @Override
     public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        String modelName = modelName();
         if (documents == null) {
             throw new ChromaException(
-                    "Gemini embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+                    "Gemini embedding failed (model: " + modelName + "): documents must not be null");
         }
         if (documents.isEmpty()) {
             throw new ChromaException(
-                    "Gemini embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+                    "Gemini embedding failed (model: " + modelName + "): documents must not be empty");
         }
-        String modelName = configParams.get(Constants.EF_PARAMS_MODEL).toString();
+        for (int docIndex = 0; docIndex < documents.size(); docIndex++) {
+            if (documents.get(docIndex) == null) {
+                throw new ChromaException(
+                        "Gemini embedding failed (model: " + modelName
+                                + "): document at index " + docIndex + " must not be null");
+            }
+        }
         com.google.genai.Client client = (com.google.genai.Client) getClient();
         try {
             List<Embedding> results = new ArrayList<Embedding>();
-            for (String doc : documents) {
+            for (int docIndex = 0; docIndex < documents.size(); docIndex++) {
+                String doc = documents.get(docIndex);
                 com.google.genai.types.EmbedContentResponse response = client.models.embedContent(
                         modelName,
                         doc,
                         null
                 );
-                List<com.google.genai.types.ContentEmbedding> embeddings = response.embeddings()
-                        .orElseThrow(new java.util.function.Supplier<RuntimeException>() {
-                            @Override
-                            public RuntimeException get() {
-                                return new RuntimeException("Gemini returned no embeddings");
-                            }
-                        });
-                com.google.genai.types.ContentEmbedding contentEmbedding = embeddings.get(0);
-                List<Float> values = contentEmbedding.values()
-                        .orElseThrow(new java.util.function.Supplier<RuntimeException>() {
-                            @Override
-                            public RuntimeException get() {
-                                return new RuntimeException("Gemini embedding has no values");
-                            }
-                        });
-                float[] floatArray = new float[values.size()];
-                for (int i = 0; i < values.size(); i++) {
-                    floatArray[i] = values.get(i);
-                }
-                results.add(new Embedding(floatArray));
+                results.add(toEmbedding(response, modelName));
             }
             if (results.size() != documents.size()) {
                 throw new ChromaException(
@@ -148,5 +138,31 @@ public class GeminiEmbeddingFunction implements EmbeddingFunction {
     @Override
     public List<Embedding> embedDocuments(String[] documents) throws EFException {
         return embedDocuments(Arrays.asList(documents));
+    }
+
+    private String modelName() {
+        Object model = configParams.get(Constants.EF_PARAMS_MODEL);
+        return model != null ? model.toString() : DEFAULT_MODEL_NAME;
+    }
+
+    private Embedding toEmbedding(com.google.genai.types.EmbedContentResponse response, String modelName) {
+        List<com.google.genai.types.ContentEmbedding> embeddings = response.embeddings().orElse(null);
+        if (embeddings == null || embeddings.isEmpty()) {
+            throw new ChromaException(
+                    "Gemini embedding failed (model: " + modelName + "): Gemini returned no embeddings");
+        }
+
+        com.google.genai.types.ContentEmbedding contentEmbedding = embeddings.get(0);
+        List<Float> values = contentEmbedding.values().orElse(null);
+        if (values == null || values.isEmpty()) {
+            throw new ChromaException(
+                    "Gemini embedding failed (model: " + modelName + "): Gemini embedding has no values");
+        }
+
+        float[] floatArray = new float[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            floatArray[i] = values.get(i);
+        }
+        return new Embedding(floatArray);
     }
 }

--- a/src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
@@ -137,6 +137,9 @@ public class GeminiEmbeddingFunction implements EmbeddingFunction {
 
     @Override
     public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        if (documents == null) {
+            return embedDocuments((List<String>) null);
+        }
         return embedDocuments(Arrays.asList(documents));
     }
 

--- a/src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/gemini/GeminiEmbeddingFunction.java
@@ -1,0 +1,152 @@
+package tech.amikos.chromadb.embeddings.gemini;
+
+import tech.amikos.chromadb.Constants;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.EmbeddingFunction;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.v2.ChromaException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Embedding function that uses the Google Gemini GenAI SDK to generate embeddings.
+ *
+ * <p>Requires the {@code com.google.genai:google-genai} dependency on the classpath.
+ * The dependency is declared as optional in the POM; users must add it explicitly.</p>
+ */
+public class GeminiEmbeddingFunction implements EmbeddingFunction {
+
+    public static final String DEFAULT_MODEL_NAME = "text-embedding-004";
+    public static final String GEMINI_API_KEY_ENV = "GEMINI_API_KEY";
+
+    private final Map<String, Object> configParams = new HashMap<String, Object>();
+    private volatile Object genaiClient; // lazily initialized com.google.genai.Client
+
+    private static final List<WithParam> defaults = Arrays.asList(
+            WithParam.defaultModel(DEFAULT_MODEL_NAME)
+    );
+
+    /**
+     * Creates a GeminiEmbeddingFunction using the GEMINI_API_KEY environment variable.
+     *
+     * @throws EFException if the environment variable is not set
+     */
+    public GeminiEmbeddingFunction() throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        WithParam.apiKeyFromEnv(GEMINI_API_KEY_ENV).apply(this.configParams);
+    }
+
+    /**
+     * Creates a GeminiEmbeddingFunction with the given parameters.
+     *
+     * @param params configuration parameters (apiKey, model, etc.)
+     * @throws EFException if parameter application fails
+     */
+    public GeminiEmbeddingFunction(WithParam... params) throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        for (WithParam param : params) {
+            param.apply(this.configParams);
+        }
+    }
+
+    private Object getClient() throws EFException {
+        if (genaiClient == null) {
+            synchronized (this) {
+                if (genaiClient == null) {
+                    Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+                    if (apiKey == null) {
+                        throw new EFException("Gemini API key is required. Provide via WithParam.apiKey() or set " + GEMINI_API_KEY_ENV);
+                    }
+                    try {
+                        // Use reflection-free direct SDK call
+                        genaiClient = com.google.genai.Client.builder()
+                                .apiKey(apiKey.toString())
+                                .build();
+                    } catch (Exception e) {
+                        throw new EFException("Failed to initialize Gemini client: " + e.getMessage(), e);
+                    }
+                }
+            }
+        }
+        return genaiClient;
+    }
+
+    @Override
+    public Embedding embedQuery(String query) throws EFException {
+        if (query == null) {
+            throw new ChromaException(
+                    "Gemini embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+        }
+        return embedDocuments(Collections.singletonList(query)).get(0);
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        if (documents == null) {
+            throw new ChromaException(
+                    "Gemini embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+        }
+        if (documents.isEmpty()) {
+            throw new ChromaException(
+                    "Gemini embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+        }
+        String modelName = configParams.get(Constants.EF_PARAMS_MODEL).toString();
+        com.google.genai.Client client = (com.google.genai.Client) getClient();
+        try {
+            List<Embedding> results = new ArrayList<Embedding>();
+            for (String doc : documents) {
+                com.google.genai.types.EmbedContentResponse response = client.models.embedContent(
+                        modelName,
+                        doc,
+                        null
+                );
+                List<com.google.genai.types.ContentEmbedding> embeddings = response.embeddings()
+                        .orElseThrow(new java.util.function.Supplier<RuntimeException>() {
+                            @Override
+                            public RuntimeException get() {
+                                return new RuntimeException("Gemini returned no embeddings");
+                            }
+                        });
+                com.google.genai.types.ContentEmbedding contentEmbedding = embeddings.get(0);
+                List<Float> values = contentEmbedding.values()
+                        .orElseThrow(new java.util.function.Supplier<RuntimeException>() {
+                            @Override
+                            public RuntimeException get() {
+                                return new RuntimeException("Gemini embedding has no values");
+                            }
+                        });
+                float[] floatArray = new float[values.size()];
+                for (int i = 0; i < values.size(); i++) {
+                    floatArray[i] = values.get(i);
+                }
+                results.add(new Embedding(floatArray));
+            }
+            if (results.size() != documents.size()) {
+                throw new ChromaException(
+                        "Gemini embedding failed (model: " + modelName + "): "
+                                + "expected " + documents.size() + " embeddings, got " + results.size()
+                );
+            }
+            return results;
+        } catch (ChromaException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new EFException("Gemini embedding failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        return embedDocuments(Arrays.asList(documents));
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingRequest.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingRequest.java
@@ -1,0 +1,55 @@
+package tech.amikos.chromadb.embeddings.voyage;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Request body for the Voyage AI embeddings API.
+ */
+public class CreateEmbeddingRequest {
+
+    @SerializedName("input")
+    private List<String> input;
+
+    @SerializedName("model")
+    private String model;
+
+    @SerializedName("input_type")
+    private String inputType;
+
+    public CreateEmbeddingRequest() {
+    }
+
+    public CreateEmbeddingRequest input(List<String> input) {
+        this.input = input;
+        return this;
+    }
+
+    public CreateEmbeddingRequest model(String model) {
+        this.model = model;
+        return this;
+    }
+
+    public CreateEmbeddingRequest inputType(String inputType) {
+        this.inputType = inputType;
+        return this;
+    }
+
+    public List<String> getInput() {
+        return input;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public String getInputType() {
+        return inputType;
+    }
+
+    public String json() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java
@@ -1,0 +1,63 @@
+package tech.amikos.chromadb.embeddings.voyage;
+
+import com.google.gson.annotations.SerializedName;
+import tech.amikos.chromadb.Embedding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response body from the Voyage AI embeddings API.
+ */
+public class CreateEmbeddingResponse {
+
+    @SerializedName("data")
+    private List<DataItem> data;
+
+    @SerializedName("usage")
+    private Usage usage;
+
+    public List<DataItem> getData() {
+        return data;
+    }
+
+    /**
+     * Converts the response data items to a list of Embedding objects.
+     *
+     * @return list of embeddings in order of their index
+     */
+    public List<Embedding> toEmbeddings() {
+        List<Embedding> embeddings = new ArrayList<Embedding>();
+        if (data != null) {
+            for (DataItem item : data) {
+                float[] floatArray = new float[item.embedding.size()];
+                for (int i = 0; i < item.embedding.size(); i++) {
+                    floatArray[i] = item.embedding.get(i);
+                }
+                embeddings.add(new Embedding(floatArray));
+            }
+        }
+        return embeddings;
+    }
+
+    public static class DataItem {
+        @SerializedName("embedding")
+        List<Float> embedding;
+
+        @SerializedName("index")
+        int index;
+
+        public List<Float> getEmbedding() {
+            return embedding;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+    }
+
+    static class Usage {
+        @SerializedName("total_tokens")
+        int totalTokens;
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/voyage/CreateEmbeddingResponse.java
@@ -2,6 +2,7 @@ package tech.amikos.chromadb.embeddings.voyage;
 
 import com.google.gson.annotations.SerializedName;
 import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.v2.ChromaException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,10 +30,26 @@ public class CreateEmbeddingResponse {
     public List<Embedding> toEmbeddings() {
         List<Embedding> embeddings = new ArrayList<Embedding>();
         if (data != null) {
-            for (DataItem item : data) {
+            for (int itemIndex = 0; itemIndex < data.size(); itemIndex++) {
+                DataItem item = data.get(itemIndex);
+                if (item == null) {
+                    throw new ChromaException(
+                            "Voyage embedding failed: response data item at index " + itemIndex + " was null");
+                }
+                if (item.embedding == null) {
+                    throw new ChromaException(
+                            "Voyage embedding failed: response data item at index " + itemIndex
+                                    + " has no embedding");
+                }
                 float[] floatArray = new float[item.embedding.size()];
                 for (int i = 0; i < item.embedding.size(); i++) {
-                    floatArray[i] = item.embedding.get(i);
+                    Float value = item.embedding.get(i);
+                    if (value == null) {
+                        throw new ChromaException(
+                                "Voyage embedding failed: response data item at index " + itemIndex
+                                        + " has null embedding value at position " + i);
+                    }
+                    floatArray[i] = value;
                 }
                 embeddings.add(new Embedding(floatArray));
             }

--- a/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
@@ -1,0 +1,143 @@
+package tech.amikos.chromadb.embeddings.voyage;
+
+import com.google.gson.Gson;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import tech.amikos.chromadb.Constants;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.EmbeddingFunction;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.v2.ChromaException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static tech.amikos.chromadb.Constants.JSON;
+
+/**
+ * Embedding function that uses the Voyage AI API to generate embeddings.
+ *
+ * <p>Uses OkHttp (already a compile dependency) to call the Voyage REST API.
+ * No additional Maven dependencies are required.</p>
+ */
+public class VoyageEmbeddingFunction implements EmbeddingFunction {
+
+    static String DEFAULT_BASE_API = "https://api.voyageai.com/v1/embeddings";
+    public static final String DEFAULT_MODEL_NAME = "voyage-3.5";
+    public static final String VOYAGE_API_KEY_ENV = "VOYAGE_API_KEY";
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final Gson gson = new Gson();
+    private final Map<String, Object> configParams = new HashMap<String, Object>();
+
+    private static final List<WithParam> defaults = Arrays.asList(
+            WithParam.baseAPI(DEFAULT_BASE_API),
+            WithParam.defaultModel(DEFAULT_MODEL_NAME)
+    );
+
+    /**
+     * Creates a VoyageEmbeddingFunction using the VOYAGE_API_KEY environment variable.
+     *
+     * @throws EFException if the environment variable is not set
+     */
+    public VoyageEmbeddingFunction() throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        WithParam.apiKeyFromEnv(VOYAGE_API_KEY_ENV).apply(this.configParams);
+    }
+
+    /**
+     * Creates a VoyageEmbeddingFunction with the given parameters.
+     *
+     * @param params configuration parameters (apiKey, model, baseAPI, etc.)
+     * @throws EFException if parameter application fails
+     */
+    public VoyageEmbeddingFunction(WithParam... params) throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        for (WithParam param : params) {
+            param.apply(this.configParams);
+        }
+    }
+
+    private CreateEmbeddingResponse callApi(CreateEmbeddingRequest req) throws EFException {
+        String baseApi = configParams.get(Constants.EF_PARAMS_BASE_API).toString();
+        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+
+        Request request = new Request.Builder()
+                .url(baseApi)
+                .post(RequestBody.create(req.json(), JSON))
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Authorization", "Bearer " + (apiKey != null ? apiKey.toString() : ""))
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new ChromaException(
+                        "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): "
+                                + response.code() + " " + response.message()
+                );
+            }
+            String responseData = response.body().string();
+            return gson.fromJson(responseData, CreateEmbeddingResponse.class);
+        } catch (ChromaException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new EFException("Voyage embedding failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Embedding embedQuery(String query) throws EFException {
+        if (query == null) {
+            throw new ChromaException(
+                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+        }
+        CreateEmbeddingRequest req = new CreateEmbeddingRequest()
+                .model(configParams.get(Constants.EF_PARAMS_MODEL).toString())
+                .input(Collections.singletonList(query))
+                .inputType("query");
+        CreateEmbeddingResponse response = callApi(req);
+        return response.toEmbeddings().get(0);
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        if (documents == null) {
+            throw new ChromaException(
+                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+        }
+        if (documents.isEmpty()) {
+            throw new ChromaException(
+                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+        }
+        String modelName = configParams.get(Constants.EF_PARAMS_MODEL).toString();
+        CreateEmbeddingRequest req = new CreateEmbeddingRequest()
+                .model(modelName)
+                .input(documents)
+                .inputType("document");
+        CreateEmbeddingResponse response = callApi(req);
+        List<Embedding> result = response.toEmbeddings();
+        if (result.size() != documents.size()) {
+            throw new ChromaException(
+                    "Voyage embedding failed (model: " + modelName + "): "
+                            + "expected " + documents.size() + " embeddings, got " + result.size()
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        return embedDocuments(Arrays.asList(documents));
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
@@ -114,24 +114,27 @@ public class VoyageEmbeddingFunction implements EmbeddingFunction {
             throw e;
         } catch (IOException e) {
             throw new EFException("Voyage embedding failed: " + e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new ChromaException("Voyage embedding failed (model: " + modelName + "): " + e.getMessage(), e);
         }
     }
 
     @Override
     public Embedding embedQuery(String query) throws EFException {
+        String modelName = modelName();
         if (query == null) {
             throw new ChromaException(
-                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): query must not be null");
+                    "Voyage embedding failed (model: " + modelName + "): query must not be null");
         }
         CreateEmbeddingRequest req = new CreateEmbeddingRequest()
-                .model(configParams.get(Constants.EF_PARAMS_MODEL).toString())
+                .model(modelName)
                 .input(Collections.singletonList(query))
                 .inputType("query");
         CreateEmbeddingResponse response = callApi(req);
         List<Embedding> embeddings = response.toEmbeddings();
         if (embeddings.isEmpty()) {
             throw new ChromaException(
-                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL)
+                    "Voyage embedding failed (model: " + modelName
                             + "): response did not contain embeddings");
         }
         return embeddings.get(0);
@@ -139,15 +142,15 @@ public class VoyageEmbeddingFunction implements EmbeddingFunction {
 
     @Override
     public List<Embedding> embedDocuments(List<String> documents) throws EFException {
+        String modelName = modelName();
         if (documents == null) {
             throw new ChromaException(
-                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be null");
+                    "Voyage embedding failed (model: " + modelName + "): documents must not be null");
         }
         if (documents.isEmpty()) {
             throw new ChromaException(
-                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): documents must not be empty");
+                    "Voyage embedding failed (model: " + modelName + "): documents must not be empty");
         }
-        String modelName = configParams.get(Constants.EF_PARAMS_MODEL).toString();
         CreateEmbeddingRequest req = new CreateEmbeddingRequest()
                 .model(modelName)
                 .input(documents)

--- a/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
@@ -168,6 +168,9 @@ public class VoyageEmbeddingFunction implements EmbeddingFunction {
 
     @Override
     public List<Embedding> embedDocuments(String[] documents) throws EFException {
+        if (documents == null) {
+            return embedDocuments((List<String>) null);
+        }
         return embedDocuments(Arrays.asList(documents));
     }
 

--- a/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/embeddings/voyage/VoyageEmbeddingFunction.java
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import tech.amikos.chromadb.Constants;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.Embedding;
@@ -71,24 +72,44 @@ public class VoyageEmbeddingFunction implements EmbeddingFunction {
 
     private CreateEmbeddingResponse callApi(CreateEmbeddingRequest req) throws EFException {
         String baseApi = configParams.get(Constants.EF_PARAMS_BASE_API).toString();
-        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+        String modelName = modelName();
+        String apiKey = requireApiKey(modelName);
 
         Request request = new Request.Builder()
                 .url(baseApi)
                 .post(RequestBody.create(req.json(), JSON))
                 .addHeader("Accept", "application/json")
                 .addHeader("Content-Type", "application/json")
-                .addHeader("Authorization", "Bearer " + (apiKey != null ? apiKey.toString() : ""))
+                .addHeader("Authorization", "Bearer " + apiKey)
                 .build();
         try (Response response = client.newCall(request).execute()) {
+            ResponseBody responseBody = response.body();
             if (!response.isSuccessful()) {
+                String body = responseBody != null ? responseBody.string() : "";
                 throw new ChromaException(
-                        "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL) + "): "
+                        "Voyage embedding failed (model: " + modelName + "): "
                                 + response.code() + " " + response.message()
+                                + (body.isEmpty() ? "" : " - " + body)
                 );
             }
-            String responseData = response.body().string();
-            return gson.fromJson(responseData, CreateEmbeddingResponse.class);
+            if (responseBody == null) {
+                throw new ChromaException(
+                        "Voyage embedding failed (model: " + modelName + "): response body was empty"
+                );
+            }
+            String responseData = responseBody.string();
+            if (responseData.trim().isEmpty()) {
+                throw new ChromaException(
+                        "Voyage embedding failed (model: " + modelName + "): response body was empty"
+                );
+            }
+            CreateEmbeddingResponse parsed = gson.fromJson(responseData, CreateEmbeddingResponse.class);
+            if (parsed == null) {
+                throw new ChromaException(
+                        "Voyage embedding failed (model: " + modelName + "): response could not be parsed"
+                );
+            }
+            return parsed;
         } catch (ChromaException e) {
             throw e;
         } catch (IOException e) {
@@ -107,7 +128,13 @@ public class VoyageEmbeddingFunction implements EmbeddingFunction {
                 .input(Collections.singletonList(query))
                 .inputType("query");
         CreateEmbeddingResponse response = callApi(req);
-        return response.toEmbeddings().get(0);
+        List<Embedding> embeddings = response.toEmbeddings();
+        if (embeddings.isEmpty()) {
+            throw new ChromaException(
+                    "Voyage embedding failed (model: " + configParams.get(Constants.EF_PARAMS_MODEL)
+                            + "): response did not contain embeddings");
+        }
+        return embeddings.get(0);
     }
 
     @Override
@@ -139,5 +166,20 @@ public class VoyageEmbeddingFunction implements EmbeddingFunction {
     @Override
     public List<Embedding> embedDocuments(String[] documents) throws EFException {
         return embedDocuments(Arrays.asList(documents));
+    }
+
+    private String modelName() {
+        Object model = configParams.get(Constants.EF_PARAMS_MODEL);
+        return model != null ? model.toString() : DEFAULT_MODEL_NAME;
+    }
+
+    private String requireApiKey(String modelName) {
+        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+        String normalized = apiKey == null ? null : apiKey.toString().trim();
+        if (normalized == null || normalized.isEmpty()) {
+            throw new ChromaException(
+                    "Voyage embedding failed (model: " + modelName + "): API key must not be null or empty");
+        }
+        return normalized;
     }
 }

--- a/src/main/java/tech/amikos/chromadb/reranking/RerankResult.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/RerankResult.java
@@ -1,0 +1,61 @@
+package tech.amikos.chromadb.reranking;
+
+/**
+ * Immutable value type representing a single reranking result.
+ *
+ * <p>Each result contains the original document index and its relevance score.</p>
+ */
+public final class RerankResult {
+
+    private final int index;
+    private final double score;
+
+    private RerankResult(int index, double score) {
+        this.index = index;
+        this.score = score;
+    }
+
+    /**
+     * Creates a new rerank result.
+     *
+     * @param index the original index of the document in the input list
+     * @param score the relevance score assigned by the reranker
+     * @return a new RerankResult
+     */
+    public static RerankResult of(int index, double score) {
+        return new RerankResult(index, score);
+    }
+
+    /**
+     * Returns the original index of the document in the input list.
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * Returns the relevance score assigned by the reranker.
+     */
+    public double getScore() {
+        return score;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RerankResult that = (RerankResult) o;
+        return index == that.index && Double.compare(that.score, score) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        long temp = Double.doubleToLongBits(score);
+        return 31 * index + (int) (temp ^ (temp >>> 32));
+    }
+
+    @Override
+    public String toString() {
+        return "RerankResult{index=" + index + ", score=" + score + "}";
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/reranking/RerankResult.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/RerankResult.java
@@ -23,6 +23,9 @@ public final class RerankResult {
      * @return a new RerankResult
      */
     public static RerankResult of(int index, double score) {
+        if (index < 0) {
+            throw new IllegalArgumentException("index must be >= 0");
+        }
         return new RerankResult(index, score);
     }
 

--- a/src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/RerankingFunction.java
@@ -1,0 +1,24 @@
+package tech.amikos.chromadb.reranking;
+
+import tech.amikos.chromadb.EFException;
+
+import java.util.List;
+
+/**
+ * Interface for reranking documents by relevance to a query.
+ *
+ * <p>Implementations call external reranking services (e.g. Cohere, Jina)
+ * to score and sort documents by relevance.</p>
+ */
+public interface RerankingFunction {
+
+    /**
+     * Reranks the given documents by relevance to the query.
+     *
+     * @param query     the query string
+     * @param documents the documents to rerank
+     * @return results sorted by descending relevance score
+     * @throws EFException if the reranking call fails
+     */
+    List<RerankResult> rerank(String query, List<String> documents) throws EFException;
+}

--- a/src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java
@@ -1,0 +1,109 @@
+package tech.amikos.chromadb.reranking.cohere;
+
+import com.google.gson.Gson;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import tech.amikos.chromadb.Constants;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.reranking.RerankResult;
+import tech.amikos.chromadb.reranking.RerankingFunction;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static tech.amikos.chromadb.Constants.JSON;
+
+/**
+ * Reranking function using the Cohere v2 rerank API.
+ *
+ * <p>Usage:</p>
+ * <pre>{@code
+ * RerankingFunction reranker = new CohereRerankingFunction(WithParam.apiKey("your-key"));
+ * List<RerankResult> results = reranker.rerank("query", documents);
+ * }</pre>
+ */
+public class CohereRerankingFunction implements RerankingFunction {
+
+    static String DEFAULT_BASE_API = "https://api.cohere.com/v2/rerank";
+    public static final String DEFAULT_MODEL_NAME = "rerank-v3.5";
+    public static final String COHERE_API_KEY_ENV = "COHERE_API_KEY";
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final Gson gson = new Gson();
+    private final Map<String, Object> configParams = new HashMap<String, Object>();
+
+    private static final List<WithParam> defaults = Arrays.asList(
+            WithParam.baseAPI(DEFAULT_BASE_API),
+            WithParam.defaultModel(DEFAULT_MODEL_NAME)
+    );
+
+    /**
+     * Creates a Cohere reranking function with the given parameters.
+     *
+     * @param params configuration parameters (at minimum, WithParam.apiKey)
+     * @throws EFException if required parameters are missing
+     */
+    public CohereRerankingFunction(WithParam... params) throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        for (WithParam param : params) {
+            param.apply(this.configParams);
+        }
+    }
+
+    @Override
+    public List<RerankResult> rerank(String query, List<String> documents) throws EFException {
+        String baseApi = configParams.containsKey(Constants.EF_PARAMS_BASE_API)
+                ? configParams.get(Constants.EF_PARAMS_BASE_API).toString()
+                : DEFAULT_BASE_API;
+
+        String model = configParams.get(Constants.EF_PARAMS_MODEL).toString();
+        RerankRequest rerankRequest = new RerankRequest(model, query, documents);
+
+        Request request = new Request.Builder()
+                .url(baseApi)
+                .post(RequestBody.create(rerankRequest.json(), JSON))
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Authorization", "Bearer " + configParams.get(Constants.EF_PARAMS_API_KEY).toString())
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                String body = response.body() != null ? response.body().string() : "";
+                throw new EFException("Cohere rerank failed: HTTP " + response.code() + " - " + body);
+            }
+
+            String responseData = response.body().string();
+            RerankResponse rerankResponse = gson.fromJson(responseData, RerankResponse.class);
+
+            List<RerankResult> results = new ArrayList<RerankResult>();
+            for (RerankResponse.Result r : rerankResponse.results) {
+                results.add(RerankResult.of(r.index, r.relevance_score));
+            }
+
+            Collections.sort(results, new Comparator<RerankResult>() {
+                @Override
+                public int compare(RerankResult a, RerankResult b) {
+                    return Double.compare(b.getScore(), a.getScore());
+                }
+            });
+
+            return results;
+        } catch (EFException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new EFException(e);
+        }
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/cohere/CohereRerankingFunction.java
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import tech.amikos.chromadb.Constants;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.embeddings.WithParam;
@@ -63,11 +64,11 @@ public class CohereRerankingFunction implements RerankingFunction {
 
     @Override
     public List<RerankResult> rerank(String query, List<String> documents) throws EFException {
+        String model = modelName();
+        validateInputs(query, documents, model);
         String baseApi = configParams.containsKey(Constants.EF_PARAMS_BASE_API)
                 ? configParams.get(Constants.EF_PARAMS_BASE_API).toString()
                 : DEFAULT_BASE_API;
-
-        String model = configParams.get(Constants.EF_PARAMS_MODEL).toString();
         RerankRequest rerankRequest = new RerankRequest(model, query, documents);
 
         Request request = new Request.Builder()
@@ -75,17 +76,28 @@ public class CohereRerankingFunction implements RerankingFunction {
                 .post(RequestBody.create(rerankRequest.json(), JSON))
                 .addHeader("Accept", "application/json")
                 .addHeader("Content-Type", "application/json")
-                .addHeader("Authorization", "Bearer " + configParams.get(Constants.EF_PARAMS_API_KEY).toString())
+                .addHeader("Authorization", "Bearer " + requireApiKey(model))
                 .build();
 
         try (Response response = client.newCall(request).execute()) {
+            ResponseBody responseBody = response.body();
             if (!response.isSuccessful()) {
-                String body = response.body() != null ? response.body().string() : "";
+                String body = responseBody != null ? responseBody.string() : "";
                 throw new EFException("Cohere rerank failed: HTTP " + response.code() + " - " + body);
             }
 
-            String responseData = response.body().string();
+            if (responseBody == null) {
+                throw new EFException("Cohere rerank failed (model: " + model + "): response body was empty");
+            }
+
+            String responseData = responseBody.string();
+            if (responseData.trim().isEmpty()) {
+                throw new EFException("Cohere rerank failed (model: " + model + "): response body was empty");
+            }
             RerankResponse rerankResponse = gson.fromJson(responseData, RerankResponse.class);
+            if (rerankResponse == null || rerankResponse.results == null) {
+                throw new EFException("Cohere rerank failed (model: " + model + "): response did not contain results");
+            }
 
             List<RerankResult> results = new ArrayList<RerankResult>();
             for (RerankResponse.Result r : rerankResponse.results) {
@@ -103,7 +115,35 @@ public class CohereRerankingFunction implements RerankingFunction {
         } catch (EFException e) {
             throw e;
         } catch (IOException e) {
-            throw new EFException(e);
+            throw new EFException("Cohere rerank failed: " + e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new EFException("Cohere rerank failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String modelName() {
+        Object model = configParams.get(Constants.EF_PARAMS_MODEL);
+        return model != null ? model.toString() : DEFAULT_MODEL_NAME;
+    }
+
+    private String requireApiKey(String model) throws EFException {
+        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+        String normalized = apiKey == null ? null : apiKey.toString().trim();
+        if (normalized == null || normalized.isEmpty()) {
+            throw new EFException("Cohere rerank failed (model: " + model + "): API key must not be null or empty");
+        }
+        return normalized;
+    }
+
+    private void validateInputs(String query, List<String> documents, String model) throws EFException {
+        if (query == null) {
+            throw new EFException("Cohere rerank failed (model: " + model + "): query must not be null");
+        }
+        if (documents == null) {
+            throw new EFException("Cohere rerank failed (model: " + model + "): documents must not be null");
+        }
+        if (documents.isEmpty()) {
+            throw new EFException("Cohere rerank failed (model: " + model + "): documents must not be empty");
         }
     }
 }

--- a/src/main/java/tech/amikos/chromadb/reranking/cohere/RerankRequest.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/cohere/RerankRequest.java
@@ -1,0 +1,25 @@
+package tech.amikos.chromadb.reranking.cohere;
+
+import com.google.gson.Gson;
+
+import java.util.List;
+
+/**
+ * Request body for the Cohere v2 rerank API.
+ */
+class RerankRequest {
+
+    private final String model;
+    private final String query;
+    private final List<String> documents;
+
+    RerankRequest(String model, String query, List<String> documents) {
+        this.model = model;
+        this.query = query;
+        this.documents = documents;
+    }
+
+    String json() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/reranking/cohere/RerankResponse.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/cohere/RerankResponse.java
@@ -1,0 +1,22 @@
+package tech.amikos.chromadb.reranking.cohere;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Response body from the Cohere v2 rerank API.
+ */
+class RerankResponse {
+
+    @SerializedName("results")
+    List<Result> results;
+
+    static class Result {
+        @SerializedName("index")
+        int index;
+
+        @SerializedName("relevance_score")
+        double relevance_score;
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import tech.amikos.chromadb.Constants;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.embeddings.WithParam;
@@ -63,11 +64,11 @@ public class JinaRerankingFunction implements RerankingFunction {
 
     @Override
     public List<RerankResult> rerank(String query, List<String> documents) throws EFException {
+        String model = modelName();
+        validateInputs(query, documents, model);
         String baseApi = configParams.containsKey(Constants.EF_PARAMS_BASE_API)
                 ? configParams.get(Constants.EF_PARAMS_BASE_API).toString()
                 : DEFAULT_BASE_API;
-
-        String model = configParams.get(Constants.EF_PARAMS_MODEL).toString();
         RerankRequest rerankRequest = new RerankRequest(model, query, documents);
 
         Request request = new Request.Builder()
@@ -75,17 +76,28 @@ public class JinaRerankingFunction implements RerankingFunction {
                 .post(RequestBody.create(rerankRequest.json(), JSON))
                 .addHeader("Accept", "application/json")
                 .addHeader("Content-Type", "application/json")
-                .addHeader("Authorization", "Bearer " + configParams.get(Constants.EF_PARAMS_API_KEY).toString())
+                .addHeader("Authorization", "Bearer " + requireApiKey(model))
                 .build();
 
         try (Response response = client.newCall(request).execute()) {
+            ResponseBody responseBody = response.body();
             if (!response.isSuccessful()) {
-                String body = response.body() != null ? response.body().string() : "";
+                String body = responseBody != null ? responseBody.string() : "";
                 throw new EFException("Jina rerank failed: HTTP " + response.code() + " - " + body);
             }
 
-            String responseData = response.body().string();
+            if (responseBody == null) {
+                throw new EFException("Jina rerank failed (model: " + model + "): response body was empty");
+            }
+
+            String responseData = responseBody.string();
+            if (responseData.trim().isEmpty()) {
+                throw new EFException("Jina rerank failed (model: " + model + "): response body was empty");
+            }
             RerankResponse rerankResponse = gson.fromJson(responseData, RerankResponse.class);
+            if (rerankResponse == null || rerankResponse.results == null) {
+                throw new EFException("Jina rerank failed (model: " + model + "): response did not contain results");
+            }
 
             List<RerankResult> results = new ArrayList<RerankResult>();
             for (RerankResponse.Result r : rerankResponse.results) {
@@ -103,7 +115,35 @@ public class JinaRerankingFunction implements RerankingFunction {
         } catch (EFException e) {
             throw e;
         } catch (IOException e) {
-            throw new EFException(e);
+            throw new EFException("Jina rerank failed: " + e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new EFException("Jina rerank failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String modelName() {
+        Object model = configParams.get(Constants.EF_PARAMS_MODEL);
+        return model != null ? model.toString() : DEFAULT_MODEL_NAME;
+    }
+
+    private String requireApiKey(String model) throws EFException {
+        Object apiKey = configParams.get(Constants.EF_PARAMS_API_KEY);
+        String normalized = apiKey == null ? null : apiKey.toString().trim();
+        if (normalized == null || normalized.isEmpty()) {
+            throw new EFException("Jina rerank failed (model: " + model + "): API key must not be null or empty");
+        }
+        return normalized;
+    }
+
+    private void validateInputs(String query, List<String> documents, String model) throws EFException {
+        if (query == null) {
+            throw new EFException("Jina rerank failed (model: " + model + "): query must not be null");
+        }
+        if (documents == null) {
+            throw new EFException("Jina rerank failed (model: " + model + "): documents must not be null");
+        }
+        if (documents.isEmpty()) {
+            throw new EFException("Jina rerank failed (model: " + model + "): documents must not be empty");
         }
     }
 }

--- a/src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/jina/JinaRerankingFunction.java
@@ -1,0 +1,109 @@
+package tech.amikos.chromadb.reranking.jina;
+
+import com.google.gson.Gson;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import tech.amikos.chromadb.Constants;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.reranking.RerankResult;
+import tech.amikos.chromadb.reranking.RerankingFunction;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static tech.amikos.chromadb.Constants.JSON;
+
+/**
+ * Reranking function using the Jina v1 rerank API.
+ *
+ * <p>Usage:</p>
+ * <pre>{@code
+ * RerankingFunction reranker = new JinaRerankingFunction(WithParam.apiKey("your-key"));
+ * List<RerankResult> results = reranker.rerank("query", documents);
+ * }</pre>
+ */
+public class JinaRerankingFunction implements RerankingFunction {
+
+    static String DEFAULT_BASE_API = "https://api.jina.ai/v1/rerank";
+    public static final String DEFAULT_MODEL_NAME = "jina-reranker-v2-base-multilingual";
+    public static final String JINA_API_KEY_ENV = "JINA_API_KEY";
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final Gson gson = new Gson();
+    private final Map<String, Object> configParams = new HashMap<String, Object>();
+
+    private static final List<WithParam> defaults = Arrays.asList(
+            WithParam.baseAPI(DEFAULT_BASE_API),
+            WithParam.defaultModel(DEFAULT_MODEL_NAME)
+    );
+
+    /**
+     * Creates a Jina reranking function with the given parameters.
+     *
+     * @param params configuration parameters (at minimum, WithParam.apiKey)
+     * @throws EFException if required parameters are missing
+     */
+    public JinaRerankingFunction(WithParam... params) throws EFException {
+        for (WithParam param : defaults) {
+            param.apply(this.configParams);
+        }
+        for (WithParam param : params) {
+            param.apply(this.configParams);
+        }
+    }
+
+    @Override
+    public List<RerankResult> rerank(String query, List<String> documents) throws EFException {
+        String baseApi = configParams.containsKey(Constants.EF_PARAMS_BASE_API)
+                ? configParams.get(Constants.EF_PARAMS_BASE_API).toString()
+                : DEFAULT_BASE_API;
+
+        String model = configParams.get(Constants.EF_PARAMS_MODEL).toString();
+        RerankRequest rerankRequest = new RerankRequest(model, query, documents);
+
+        Request request = new Request.Builder()
+                .url(baseApi)
+                .post(RequestBody.create(rerankRequest.json(), JSON))
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Authorization", "Bearer " + configParams.get(Constants.EF_PARAMS_API_KEY).toString())
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                String body = response.body() != null ? response.body().string() : "";
+                throw new EFException("Jina rerank failed: HTTP " + response.code() + " - " + body);
+            }
+
+            String responseData = response.body().string();
+            RerankResponse rerankResponse = gson.fromJson(responseData, RerankResponse.class);
+
+            List<RerankResult> results = new ArrayList<RerankResult>();
+            for (RerankResponse.Result r : rerankResponse.results) {
+                results.add(RerankResult.of(r.index, r.relevance_score));
+            }
+
+            Collections.sort(results, new Comparator<RerankResult>() {
+                @Override
+                public int compare(RerankResult a, RerankResult b) {
+                    return Double.compare(b.getScore(), a.getScore());
+                }
+            });
+
+            return results;
+        } catch (EFException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new EFException(e);
+        }
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/reranking/jina/RerankRequest.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/jina/RerankRequest.java
@@ -1,0 +1,25 @@
+package tech.amikos.chromadb.reranking.jina;
+
+import com.google.gson.Gson;
+
+import java.util.List;
+
+/**
+ * Request body for the Jina v1 rerank API.
+ */
+class RerankRequest {
+
+    private final String model;
+    private final String query;
+    private final List<String> documents;
+
+    RerankRequest(String model, String query, List<String> documents) {
+        this.model = model;
+        this.query = query;
+        this.documents = documents;
+    }
+
+    String json() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/reranking/jina/RerankResponse.java
+++ b/src/main/java/tech/amikos/chromadb/reranking/jina/RerankResponse.java
@@ -1,0 +1,22 @@
+package tech.amikos.chromadb.reranking.jina;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Response body from the Jina v1 rerank API.
+ */
+class RerankResponse {
+
+    @SerializedName("results")
+    List<Result> results;
+
+    static class Result {
+        @SerializedName("index")
+        int index;
+
+        @SerializedName("relevance_score")
+        double relevance_score;
+    }
+}

--- a/src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
+++ b/src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
@@ -30,7 +30,27 @@ public final class EmbeddingFunctionResolver {
      * @throws ChromaException if descriptor values are invalid/unsupported or provider initialization fails
      */
     static EmbeddingFunction resolve(EmbeddingFunctionSpec spec) {
-        return EmbeddingFunctionRegistry.getDefault().resolveDense(spec);
+        if (spec == null) return null;
+        if (!spec.isKnownType()) {
+            throw new ChromaException(
+                    "Unsupported embedding function type '" + spec.getType()
+                    + "' for provider '" + spec.getName()
+                    + "'. Only 'known' types can be auto-resolved. "
+                    + "Pass your own EmbeddingFunction or use queryEmbeddings to supply vectors directly."
+            );
+        }
+        try {
+            return EmbeddingFunctionRegistry.getDefault().resolveDense(spec);
+        } catch (ChromaException e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("Unsupported")) {
+                throw new ChromaException(
+                        "Unsupported embedding provider '" + spec.getName()
+                        + "'. Pass your own EmbeddingFunction or use queryEmbeddings to supply vectors directly."
+                );
+            }
+            throw e;
+        }
     }
 
     /**

--- a/src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
+++ b/src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
@@ -1,83 +1,45 @@
 package tech.amikos.chromadb.v2;
 
-import tech.amikos.chromadb.EFException;
-import tech.amikos.chromadb.embeddings.DefaultEmbeddingFunction;
 import tech.amikos.chromadb.embeddings.EmbeddingFunction;
+import tech.amikos.chromadb.embeddings.EmbeddingFunctionRegistry;
 import tech.amikos.chromadb.embeddings.WithParam;
-import tech.amikos.chromadb.embeddings.cohere.CohereEmbeddingFunction;
 import tech.amikos.chromadb.embeddings.hf.HuggingFaceEmbeddingFunction;
-import tech.amikos.chromadb.embeddings.ollama.OllamaEmbeddingFunction;
-import tech.amikos.chromadb.embeddings.openai.OpenAIEmbeddingFunction;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-/** Builds runtime embedding-function instances from configuration/schema descriptors. */
-final class EmbeddingFunctionResolver {
+/**
+ * Builds runtime embedding-function instances from configuration/schema descriptors.
+ *
+ * <p>Delegates to {@link EmbeddingFunctionRegistry#getDefault()} for provider resolution.
+ * The static helper methods ({@link #buildParams}, {@link #buildHuggingFaceParams}) are
+ * public so the registry can reuse the parameter-building logic.</p>
+ */
+public final class EmbeddingFunctionResolver {
 
     private EmbeddingFunctionResolver() {}
 
     /**
      * Resolves a runtime embedding function from a descriptor.
      *
-     * <p>Returns {@code null} when {@code spec} is {@code null}. For non-null descriptors this method
-     * either returns an initialized embedding function or throws {@link ChromaException} with context.
-     * Unsupported descriptor type/provider values fail fast with actionable guidance.</p>
+     * <p>Delegates to {@link EmbeddingFunctionRegistry#getDefault()}.{@link
+     * EmbeddingFunctionRegistry#resolveDense(EmbeddingFunctionSpec) resolveDense(spec)}.</p>
      *
      * @throws ChromaException if descriptor values are invalid/unsupported or provider initialization fails
      */
     static EmbeddingFunction resolve(EmbeddingFunctionSpec spec) {
-        if (spec == null) {
-            return null;
-        }
-        String rawProviderName = spec.getName();
-        if (rawProviderName == null || rawProviderName.trim().isEmpty()) {
-            throw new ChromaException(
-                    "Embedding function provider name is missing. "
-                            + "Use queryEmbeddings(...) or set a valid embedding_function descriptor."
-            );
-        }
-        String type = spec.getType();
-        if (type != null && !"known".equals(type.toLowerCase(Locale.ROOT))) {
-            throw unsupported("Unsupported embedding function type '" + type + "' for provider '" + rawProviderName + "'");
-        }
-
-        String provider = rawProviderName.trim().toLowerCase(Locale.ROOT);
-        try {
-            if ("default".equals(provider)) {
-                return new DefaultEmbeddingFunction();
-            }
-            if ("openai".equals(provider)) {
-                return new OpenAIEmbeddingFunction(buildParams(spec.getConfig(), OpenAIEmbeddingFunction.OPENAI_API_KEY_ENV));
-            }
-            if ("cohere".equals(provider)) {
-                return new CohereEmbeddingFunction(buildParams(spec.getConfig(), CohereEmbeddingFunction.COHERE_API_KEY_ENV));
-            }
-            if ("huggingface".equals(provider) || "hugging_face".equals(provider) || "hf".equals(provider)) {
-                return new HuggingFaceEmbeddingFunction(buildHuggingFaceParams(spec.getConfig()));
-            }
-            if ("ollama".equals(provider)) {
-                return new OllamaEmbeddingFunction(buildParams(spec.getConfig(), null));
-            }
-            throw unsupported("Unsupported embedding function provider '" + rawProviderName + "'");
-        } catch (ChromaException e) {
-            throw e;
-        } catch (EFException e) {
-            throw new ChromaException(
-                    "Failed to initialize embedding function provider '" + rawProviderName + "': " + e.getMessage(),
-                    e
-            );
-        } catch (RuntimeException e) {
-            throw new ChromaException(
-                    "Failed to initialize embedding function provider '" + rawProviderName + "': " + e.getMessage(),
-                    e
-            );
-        }
+        return EmbeddingFunctionRegistry.getDefault().resolveDense(spec);
     }
 
-    private static WithParam[] buildHuggingFaceParams(Map<String, Object> config) {
+    /**
+     * Builds a HuggingFace-specific parameter array from config map, including api_type handling.
+     *
+     * @param config the configuration map (may be null)
+     * @return parameter array for HuggingFaceEmbeddingFunction constructor
+     */
+    public static WithParam[] buildHuggingFaceParams(Map<String, Object> config) {
         List<WithParam> params = buildParamsList(config, HuggingFaceEmbeddingFunction.HF_API_KEY_ENV);
         if (config != null) {
             String apiType = firstString(config, "api_type", "apiType");
@@ -97,7 +59,14 @@ final class EmbeddingFunctionResolver {
         return params.toArray(new WithParam[params.size()]);
     }
 
-    private static WithParam[] buildParams(Map<String, Object> config, String defaultApiKeyEnv) {
+    /**
+     * Builds a parameter array from a config map with a default API key environment variable.
+     *
+     * @param config          the configuration map (may be null)
+     * @param defaultApiKeyEnv the default environment variable name for API key (may be null)
+     * @return parameter array suitable for embedding function constructors
+     */
+    public static WithParam[] buildParams(Map<String, Object> config, String defaultApiKeyEnv) {
         List<WithParam> params = buildParamsList(config, defaultApiKeyEnv);
         return params.toArray(new WithParam[params.size()]);
     }
@@ -130,7 +99,7 @@ final class EmbeddingFunctionResolver {
         return params;
     }
 
-    private static String firstString(Map<String, Object> map, String... keys) {
+    static String firstString(Map<String, Object> map, String... keys) {
         for (String key : keys) {
             if (!map.containsKey(key)) {
                 continue;
@@ -148,11 +117,5 @@ final class EmbeddingFunctionResolver {
             }
         }
         return null;
-    }
-
-    private static ChromaException unsupported(String message) {
-        return new ChromaException(
-                message + ". Use queryEmbeddings(...) or one of [default, openai, cohere, huggingface, ollama]."
-        );
     }
 }

--- a/src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
+++ b/src/main/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolver.java
@@ -41,14 +41,13 @@ public final class EmbeddingFunctionResolver {
         }
         try {
             return EmbeddingFunctionRegistry.getDefault().resolveDense(spec);
+        } catch (UnsupportedEmbeddingProviderException e) {
+            throw new ChromaException(
+                    "Unsupported embedding provider '" + spec.getName()
+                    + "'. Pass your own EmbeddingFunction or use queryEmbeddings to supply vectors directly.",
+                    e
+            );
         } catch (ChromaException e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("Unsupported")) {
-                throw new ChromaException(
-                        "Unsupported embedding provider '" + spec.getName()
-                        + "'. Pass your own EmbeddingFunction or use queryEmbeddings to supply vectors directly."
-                );
-            }
             throw e;
         }
     }

--- a/src/main/java/tech/amikos/chromadb/v2/UnsupportedEmbeddingProviderException.java
+++ b/src/main/java/tech/amikos/chromadb/v2/UnsupportedEmbeddingProviderException.java
@@ -1,0 +1,11 @@
+package tech.amikos.chromadb.v2;
+
+/**
+ * Signals that a requested embedding provider is not registered.
+ */
+public final class UnsupportedEmbeddingProviderException extends ChromaException {
+
+    public UnsupportedEmbeddingProviderException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
@@ -1,12 +1,17 @@
 package tech.amikos.chromadb.embeddings;
 
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.embeddings.bedrock.BedrockEmbeddingFunction;
 import tech.amikos.chromadb.v2.ChromaException;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -98,6 +103,61 @@ public class TestBedrockEmbeddingFunction {
         } catch (ChromaException e) {
             assertTrue(e.getMessage().contains("custom-bedrock-model"));
             assertTrue(e.getMessage().contains("document at index 1 must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsArrayRejectsNullWithConfiguredModel() throws EFException {
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                WithParam.model("custom-bedrock-model")
+        );
+
+        try {
+            ef.embedDocuments((String[]) null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-bedrock-model"));
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testInvalidRegionInitializationIsWrappedWithContext() throws EFException {
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                BedrockEmbeddingFunction.region(null)
+        );
+
+        try {
+            ef.embedDocuments(Collections.singletonList("doc1"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("Failed to initialize Bedrock client"));
+            assertTrue(e.getMessage().contains("AWS region must not be null or blank"));
+        }
+    }
+
+    @Test
+    public void testToEmbeddingRejectsMissingEmbeddingArray() throws Exception {
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                WithParam.model("custom-bedrock-model")
+        );
+        Method method = BedrockEmbeddingFunction.class.getDeclaredMethod(
+                "toEmbedding",
+                InvokeModelResponse.class,
+                String.class
+        );
+        method.setAccessible(true);
+
+        InvokeModelResponse response = InvokeModelResponse.builder()
+                .body(SdkBytes.fromString("{\"dimensions\":1024}", StandardCharsets.UTF_8))
+                .build();
+
+        try {
+            method.invoke(ef, response, "custom-bedrock-model");
+            fail("Expected ChromaException");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof ChromaException);
+            assertTrue(e.getCause().getMessage().contains("response missing embedding array"));
         }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
@@ -3,8 +3,11 @@ package tech.amikos.chromadb.embeddings;
 import org.junit.Test;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.embeddings.bedrock.BedrockEmbeddingFunction;
+import tech.amikos.chromadb.v2.ChromaException;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -51,5 +54,50 @@ public class TestBedrockEmbeddingFunction {
     @Test
     public void testAwsRegionEnvConstant() {
         assertEquals("AWS_REGION", BedrockEmbeddingFunction.AWS_REGION_ENV);
+    }
+
+    @Test
+    public void testEmbedQueryRejectsNullWithConfiguredModel() throws EFException {
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                WithParam.model("custom-bedrock-model")
+        );
+
+        try {
+            ef.embedQuery(null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-bedrock-model"));
+            assertTrue(e.getMessage().contains("query must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsNullListWithConfiguredModel() throws EFException {
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                WithParam.model("custom-bedrock-model")
+        );
+
+        try {
+            ef.embedDocuments((List<String>) null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-bedrock-model"));
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsNullElementWithIndex() throws EFException {
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                WithParam.model("custom-bedrock-model")
+        );
+
+        try {
+            ef.embedDocuments(Arrays.asList("doc1", null));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-bedrock-model"));
+            assertTrue(e.getMessage().contains("document at index 1 must not be null"));
+        }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestBedrockEmbeddingFunction.java
@@ -1,0 +1,55 @@
+package tech.amikos.chromadb.embeddings;
+
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.bedrock.BedrockEmbeddingFunction;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for BedrockEmbeddingFunction.
+ *
+ * <p>These tests verify construction and configuration behavior.
+ * Actual API calls require AWS credentials and are not tested here.</p>
+ */
+public class TestBedrockEmbeddingFunction {
+
+    @Test
+    public void testConstructWithDefaults() throws EFException {
+        // AWS SDK uses default credential chain, no API key needed at construction
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction();
+        assertNotNull(ef);
+    }
+
+    @Test
+    public void testDefaultModelName() throws Exception {
+        Field field = BedrockEmbeddingFunction.class.getDeclaredField("DEFAULT_MODEL_NAME");
+        field.setAccessible(true);
+        assertEquals("amazon.titan-embed-text-v2:0", field.get(null));
+    }
+
+    @Test
+    public void testCustomRegion() throws EFException {
+        // Construction with custom region should not throw
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                BedrockEmbeddingFunction.region("eu-west-1")
+        );
+        assertNotNull(ef);
+    }
+
+    @Test
+    public void testCustomModel() throws EFException {
+        // Construction with custom model should not throw
+        BedrockEmbeddingFunction ef = new BedrockEmbeddingFunction(
+                WithParam.model("cohere.embed-english-v3")
+        );
+        assertNotNull(ef);
+    }
+
+    @Test
+    public void testAwsRegionEnvConstant() {
+        assertEquals("AWS_REGION", BedrockEmbeddingFunction.AWS_REGION_ENV);
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
@@ -194,4 +194,23 @@ public class TestChromaCloudSpladeEmbeddingFunction {
             assertTrue(e.getMessage().contains("response body was empty"));
         }
     }
+
+    @Test
+    public void testMalformedJsonFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{not-json")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.singletonList("text"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("Chroma Cloud Splade embedding failed"));
+            assertNotNull(e.getCause());
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
@@ -126,4 +126,72 @@ public class TestChromaCloudSpladeEmbeddingFunction {
                     e.getMessage().contains("CHROMA_API_KEY"));
         }
     }
+
+    @Test
+    public void testEmbedQueryRejectsNull() throws EFException {
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedQuery(null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("query must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsNull() throws EFException {
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments((List<String>) null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsEmptyList() throws EFException {
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.<String>emptyList());
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("documents must not be empty"));
+        }
+    }
+
+    @Test
+    public void testMissingApiKeyFailsFast() throws EFException {
+        ChromaCloudSpladeEmbeddingFunction ef = new ChromaCloudSpladeEmbeddingFunction(
+                WithParam.baseAPI(wireMockUrl())
+        );
+
+        try {
+            ef.embedDocuments(Collections.singletonList("text"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("API key must not be null or empty"));
+        }
+    }
+
+    @Test
+    public void testEmptyResponseBodyFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.singletonList("text"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("response body was empty"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
@@ -1,0 +1,129 @@
+package tech.amikos.chromadb.embeddings;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.chromacloudsplade.ChromaCloudSpladeEmbeddingFunction;
+import tech.amikos.chromadb.v2.ChromaException;
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for ChromaCloudSpladeEmbeddingFunction using WireMock.
+ */
+public class TestChromaCloudSpladeEmbeddingFunction {
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+    private String wireMockUrl() {
+        return "http://localhost:" + wireMock.port() + "/api/v2/embed/splade";
+    }
+
+    private ChromaCloudSpladeEmbeddingFunction createFunction() throws EFException {
+        return new ChromaCloudSpladeEmbeddingFunction(
+                WithParam.apiKey("test-chroma-key"),
+                WithParam.baseAPI(wireMockUrl())
+        );
+    }
+
+    @Test
+    public void testEmbedDocumentsSuccess() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"indices\":[1,5,10],\"values\":[0.5,0.3,0.1]}]}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+        List<SparseVector> result = ef.embedDocuments(Collections.singletonList("text"));
+
+        assertEquals("Should return 1 vector", 1, result.size());
+        assertArrayEquals("Indices should match", new int[]{1, 5, 10}, result.get(0).getIndices());
+        assertArrayEquals("Values should match",
+                new float[]{0.5f, 0.3f, 0.1f}, result.get(0).getValues(), 0.01f);
+    }
+
+    @Test
+    public void testEmbedQuerySuccess() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"indices\":[2,7],\"values\":[0.9,0.4]}]}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+        SparseVector result = ef.embedQuery("test query");
+
+        assertNotNull("Result should not be null", result);
+        assertArrayEquals("Indices should match", new int[]{2, 7}, result.getIndices());
+    }
+
+    @Test
+    public void testAuthHeader() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"indices\":[1],\"values\":[0.5]}]}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+        ef.embedDocuments(Collections.singletonList("text"));
+
+        verify(postRequestedFor(urlEqualTo("/api/v2/embed/splade"))
+                .withHeader("Authorization", equalTo("Bearer test-chroma-key")));
+    }
+
+    @Test
+    public void testServerError() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"internal server error\"}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+        try {
+            ef.embedDocuments(Collections.singletonList("text"));
+            fail("Expected ChromaException for 500 response");
+        } catch (ChromaException e) {
+            assertTrue("Expected message to mention Splade, got: " + e.getMessage(),
+                    e.getMessage().contains("Splade"));
+        }
+    }
+
+    @Test
+    public void testMultipleDocuments() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"indices\":[1,2],\"values\":[0.5,0.3]},{\"indices\":[3,4],\"values\":[0.8,0.2]}]}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+        List<SparseVector> result = ef.embedDocuments(Arrays.asList("doc1", "doc2"));
+
+        assertEquals("Should return 2 vectors", 2, result.size());
+        assertArrayEquals("First vector indices", new int[]{1, 2}, result.get(0).getIndices());
+        assertArrayEquals("Second vector indices", new int[]{3, 4}, result.get(1).getIndices());
+    }
+
+    @Test
+    public void testApiKeyFromEnvThrowsWhenNotSet() {
+        try {
+            new ChromaCloudSpladeEmbeddingFunction();
+            fail("Expected EFException when CHROMA_API_KEY is not set");
+        } catch (EFException e) {
+            assertTrue("Expected message to mention CHROMA_API_KEY, got: " + e.getMessage(),
+                    e.getMessage().contains("CHROMA_API_KEY"));
+        }
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestChromaCloudSpladeEmbeddingFunction.java
@@ -213,4 +213,58 @@ public class TestChromaCloudSpladeEmbeddingFunction {
             assertNotNull(e.getCause());
         }
     }
+
+    @Test
+    public void testResponseResultWithoutIndicesFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"values\":[0.5]}]}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.singletonList("text"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("has no indices"));
+        }
+    }
+
+    @Test
+    public void testResponseResultWithoutValuesFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"indices\":[1]}]}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.singletonList("text"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("has no values"));
+        }
+    }
+
+    @Test
+    public void testResponseResultWithMismatchedSizesFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/api/v2/embed/splade"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"indices\":[1,2],\"values\":[0.5]}]}")));
+
+        ChromaCloudSpladeEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.singletonList("text"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("mismatched indices and values sizes"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
@@ -5,6 +5,7 @@ import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.Embedding;
 import tech.amikos.chromadb.embeddings.content.BinarySource;
 import tech.amikos.chromadb.embeddings.content.Content;
+import tech.amikos.chromadb.embeddings.content.Intent;
 import tech.amikos.chromadb.embeddings.content.Part;
 
 import java.util.ArrayList;
@@ -89,6 +90,7 @@ public class TestContentEmbeddingFunction {
         ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
             @Override
             public List<Embedding> embedContents(List<Content> contents) {
+                assertEquals(Intent.RETRIEVAL_QUERY, contents.get(0).getIntent());
                 List<Embedding> result = new ArrayList<Embedding>();
                 for (Content c : contents) {
                     result.add(Embedding.fromArray(new float[]{4.0f}));
@@ -108,6 +110,9 @@ public class TestContentEmbeddingFunction {
         ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
             @Override
             public List<Embedding> embedContents(List<Content> contents) {
+                for (Content content : contents) {
+                    assertEquals(Intent.RETRIEVAL_DOCUMENT, content.getIntent());
+                }
                 List<Embedding> result = new ArrayList<Embedding>();
                 for (Content c : contents) {
                     result.add(Embedding.fromArray(new float[]{5.0f}));
@@ -137,5 +142,32 @@ public class TestContentEmbeddingFunction {
         ContentToTextAdapter adapter = new ContentToTextAdapter(cef);
         List<Embedding> results = adapter.embedDocuments(new String[]{"a", "b"});
         assertEquals(2, results.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testContentToTextAdapterRejectsNullWrappedFunction() {
+        new ContentToTextAdapter(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTextEmbeddingAdapterRejectsNullWrappedFunction() {
+        new TextEmbeddingAdapter(null);
+    }
+
+    @Test
+    public void testDefaultEmbedContentRejectsEmptyResult() throws Exception {
+        ContentEmbeddingFunction ef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                return Collections.emptyList();
+            }
+        };
+
+        try {
+            ef.embedContent(Content.text("hi"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("embedContents returned no embeddings"));
+        }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
@@ -105,6 +105,18 @@ public class TestContentEmbeddingFunction {
         assertEquals(1, result.getDimensions());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testContentToTextAdapterRejectsNullQuery() throws Exception {
+        ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                return Collections.singletonList(Embedding.fromArray(new float[]{4.0f}));
+            }
+        };
+
+        new ContentToTextAdapter(cef).embedQuery(null);
+    }
+
     @Test
     public void testContentToTextAdapterEmbedDocumentsList() throws Exception {
         ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
@@ -145,6 +157,18 @@ public class TestContentEmbeddingFunction {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testContentToTextAdapterRejectsNullDocuments() throws Exception {
+        ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                return Collections.emptyList();
+            }
+        };
+
+        new ContentToTextAdapter(cef).embedDocuments((List<String>) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testContentToTextAdapterRejectsNullWrappedFunction() {
         new ContentToTextAdapter(null);
     }
@@ -169,5 +193,21 @@ public class TestContentEmbeddingFunction {
         } catch (EFException e) {
             assertTrue(e.getMessage().contains("embedContents returned no embeddings"));
         }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTextEmbeddingAdapterRejectsNullContents() throws Exception {
+        EmbeddingFunction dummyEf = new EmbeddingFunction() {
+            @Override
+            public Embedding embedQuery(String query) { return null; }
+
+            @Override
+            public List<Embedding> embedDocuments(List<String> documents) { return Collections.emptyList(); }
+
+            @Override
+            public List<Embedding> embedDocuments(String[] documents) { return Collections.emptyList(); }
+        };
+
+        new TextEmbeddingAdapter(dummyEf).embedContents(null);
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
@@ -1,0 +1,141 @@
+package tech.amikos.chromadb.embeddings;
+
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.content.BinarySource;
+import tech.amikos.chromadb.embeddings.content.Content;
+import tech.amikos.chromadb.embeddings.content.Part;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TestContentEmbeddingFunction {
+
+    @Test
+    public void testDefaultEmbedContentDelegatesToEmbedContents() throws Exception {
+        ContentEmbeddingFunction ef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                List<Embedding> result = new ArrayList<Embedding>();
+                for (Content c : contents) {
+                    result.add(Embedding.fromArray(new float[]{1.0f}));
+                }
+                return result;
+            }
+        };
+
+        Embedding result = ef.embedContent(Content.text("hi"));
+        assertNotNull(result);
+        assertEquals(1, result.getDimensions());
+    }
+
+    @Test
+    public void testFromTextOnlyWrapsEmbeddingFunction() throws Exception {
+        EmbeddingFunction textEf = new EmbeddingFunction() {
+            @Override
+            public Embedding embedQuery(String query) {
+                return Embedding.fromArray(new float[]{2.0f, 3.0f});
+            }
+
+            @Override
+            public List<Embedding> embedDocuments(List<String> documents) {
+                List<Embedding> result = new ArrayList<Embedding>();
+                for (String d : documents) {
+                    result.add(Embedding.fromArray(new float[]{2.0f, 3.0f}));
+                }
+                return result;
+            }
+
+            @Override
+            public List<Embedding> embedDocuments(String[] documents) {
+                return embedDocuments(Arrays.asList(documents));
+            }
+        };
+
+        ContentEmbeddingFunction cef = ContentEmbeddingFunction.fromTextOnly(textEf);
+        Embedding result = cef.embedContent(Content.text("hello"));
+        assertNotNull(result);
+        assertEquals(2, result.getDimensions());
+        assertArrayEquals(new float[]{2.0f, 3.0f}, result.asArray(), 0.001f);
+    }
+
+    @Test(expected = EFException.class)
+    public void testTextEmbeddingAdapterThrowsForNoTextPart() throws Exception {
+        EmbeddingFunction dummyEf = new EmbeddingFunction() {
+            @Override
+            public Embedding embedQuery(String query) { return null; }
+
+            @Override
+            public List<Embedding> embedDocuments(List<String> documents) { return null; }
+
+            @Override
+            public List<Embedding> embedDocuments(String[] documents) { return null; }
+        };
+
+        TextEmbeddingAdapter adapter = new TextEmbeddingAdapter(dummyEf);
+        Content imageOnly = Content.builder()
+                .part(Part.image(BinarySource.fromUrl("http://x")))
+                .build();
+        adapter.embedContents(Collections.singletonList(imageOnly));
+    }
+
+    @Test
+    public void testContentToTextAdapterEmbedQuery() throws Exception {
+        ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                List<Embedding> result = new ArrayList<Embedding>();
+                for (Content c : contents) {
+                    result.add(Embedding.fromArray(new float[]{4.0f}));
+                }
+                return result;
+            }
+        };
+
+        ContentToTextAdapter adapter = new ContentToTextAdapter(cef);
+        Embedding result = adapter.embedQuery("test");
+        assertNotNull(result);
+        assertEquals(1, result.getDimensions());
+    }
+
+    @Test
+    public void testContentToTextAdapterEmbedDocumentsList() throws Exception {
+        ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                List<Embedding> result = new ArrayList<Embedding>();
+                for (Content c : contents) {
+                    result.add(Embedding.fromArray(new float[]{5.0f}));
+                }
+                return result;
+            }
+        };
+
+        ContentToTextAdapter adapter = new ContentToTextAdapter(cef);
+        List<Embedding> results = adapter.embedDocuments(Arrays.asList("a", "b"));
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testContentToTextAdapterEmbedDocumentsArray() throws Exception {
+        ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                List<Embedding> result = new ArrayList<Embedding>();
+                for (Content c : contents) {
+                    result.add(Embedding.fromArray(new float[]{6.0f}));
+                }
+                return result;
+            }
+        };
+
+        ContentToTextAdapter adapter = new ContentToTextAdapter(cef);
+        List<Embedding> results = adapter.embedDocuments(new String[]{"a", "b"});
+        assertEquals(2, results.size());
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
@@ -6,8 +6,10 @@ import tech.amikos.chromadb.Embedding;
 import tech.amikos.chromadb.embeddings.content.BinarySource;
 import tech.amikos.chromadb.embeddings.content.Content;
 import tech.amikos.chromadb.embeddings.content.Intent;
+import tech.amikos.chromadb.embeddings.content.Modality;
 import tech.amikos.chromadb.embeddings.content.Part;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -186,6 +188,18 @@ public class TestContentEmbeddingFunction {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testContentToTextAdapterRejectsNullDocumentsArray() throws Exception {
+        ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                return Collections.emptyList();
+            }
+        };
+
+        new ContentToTextAdapter(cef).embedDocuments((String[]) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testContentToTextAdapterRejectsNullWrappedFunction() {
         new ContentToTextAdapter(null);
     }
@@ -226,5 +240,37 @@ public class TestContentEmbeddingFunction {
         };
 
         new TextEmbeddingAdapter(dummyEf).embedContents(null);
+    }
+
+    @Test
+    public void testTextEmbeddingAdapterRejectsNullTextInTextPart() throws Exception {
+        EmbeddingFunction dummyEf = new EmbeddingFunction() {
+            @Override
+            public Embedding embedQuery(String query) { return null; }
+
+            @Override
+            public List<Embedding> embedDocuments(List<String> documents) { return Collections.emptyList(); }
+
+            @Override
+            public List<Embedding> embedDocuments(String[] documents) { return Collections.emptyList(); }
+        };
+
+        Constructor<Part> constructor = Part.class.getDeclaredConstructor(
+                Modality.class,
+                String.class,
+                BinarySource.class
+        );
+        constructor.setAccessible(true);
+        Part malformedTextPart = constructor.newInstance(Modality.TEXT, null, null);
+        Content malformedContent = Content.builder()
+                .part(malformedTextPart)
+                .build();
+
+        try {
+            new TextEmbeddingAdapter(dummyEf).embedContents(Collections.singletonList(malformedContent));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("Content text part must not be null"));
+        }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestContentEmbeddingFunction.java
@@ -168,6 +168,23 @@ public class TestContentEmbeddingFunction {
         new ContentToTextAdapter(cef).embedDocuments((List<String>) null);
     }
 
+    @Test
+    public void testContentToTextAdapterRejectsNullDocumentElement() throws Exception {
+        ContentEmbeddingFunction cef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) {
+                return Collections.emptyList();
+            }
+        };
+
+        try {
+            new ContentToTextAdapter(cef).embedDocuments(Arrays.asList("a", null));
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("document at index 1 must not be null"));
+        }
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testContentToTextAdapterRejectsNullWrappedFunction() {
         new ContentToTextAdapter(null);

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
@@ -370,4 +370,22 @@ public class TestEmbeddingFunctionRegistry {
             assertTrue(e.getMessage().contains("google-genai"));
         }
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResolveContentReportsUnavailableOptionalProvider() throws Exception {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        Field field = EmbeddingFunctionRegistry.class.getDeclaredField("unavailableDenseProviders");
+        field.setAccessible(true);
+        Map<String, String> unavailable = (Map<String, String>) field.get(registry);
+        unavailable.put("google_genai", "requires optional dependency com.google.genai:google-genai on the classpath");
+
+        try {
+            registry.resolveContent(spec("google_genai"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("unavailable"));
+            assertTrue(e.getMessage().contains("google-genai"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
@@ -1,0 +1,231 @@
+package tech.amikos.chromadb.embeddings;
+
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.bm25.BM25EmbeddingFunction;
+import tech.amikos.chromadb.embeddings.content.Content;
+import tech.amikos.chromadb.embeddings.openai.OpenAIEmbeddingFunction;
+import tech.amikos.chromadb.v2.ChromaException;
+import tech.amikos.chromadb.v2.EmbeddingFunctionSpec;
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class TestEmbeddingFunctionRegistry {
+
+    private static EmbeddingFunctionSpec spec(String name) {
+        return EmbeddingFunctionSpec.builder().name(name).type("known").build();
+    }
+
+    private static EmbeddingFunctionSpec specWithConfig(String name, Map<String, Object> config) {
+        return EmbeddingFunctionSpec.builder().name(name).type("known").config(config).build();
+    }
+
+    @Test
+    public void testGetDefaultIsSingleton() {
+        assertSame(EmbeddingFunctionRegistry.getDefault(), EmbeddingFunctionRegistry.getDefault());
+    }
+
+    @Test
+    public void testResolveOpenAI() {
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put("api_key", "test-key");
+        EmbeddingFunction ef = EmbeddingFunctionRegistry.getDefault().resolveDense(specWithConfig("openai", config));
+        assertNotNull(ef);
+        assertTrue(ef instanceof OpenAIEmbeddingFunction);
+    }
+
+    @Test
+    public void testResolveCohere() {
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put("api_key", "test-key");
+        EmbeddingFunction ef = EmbeddingFunctionRegistry.getDefault().resolveDense(specWithConfig("cohere", config));
+        assertNotNull(ef);
+    }
+
+    @Test
+    public void testResolveBM25() {
+        SparseEmbeddingFunction sf = EmbeddingFunctionRegistry.getDefault().resolveSparse(spec("chroma_bm25"));
+        assertNotNull(sf);
+        assertTrue(sf instanceof BM25EmbeddingFunction);
+    }
+
+    @Test
+    public void testResolveBM25Alias() {
+        SparseEmbeddingFunction sf = EmbeddingFunctionRegistry.getDefault().resolveSparse(spec("bm25"));
+        assertNotNull(sf);
+        assertTrue(sf instanceof BM25EmbeddingFunction);
+    }
+
+    @Test
+    public void testResolveContentFallbackToDense() {
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put("api_key", "test-key");
+        ContentEmbeddingFunction cef = EmbeddingFunctionRegistry.getDefault().resolveContent(specWithConfig("openai", config));
+        assertNotNull(cef);
+    }
+
+    @Test
+    public void testResolveNullReturnsNull() {
+        assertNull(EmbeddingFunctionRegistry.getDefault().resolveDense(null));
+    }
+
+    @Test(expected = ChromaException.class)
+    public void testResolveUnknownThrows() {
+        EmbeddingFunctionRegistry.getDefault().resolveDense(spec("nonexistent"));
+    }
+
+    @Test
+    public void testCustomRegistryRegisterAndResolve() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        final EmbeddingFunction mockEf = new EmbeddingFunction() {
+            @Override
+            public Embedding embedQuery(String query) { return null; }
+            @Override
+            public List<Embedding> embedDocuments(List<String> documents) { return null; }
+            @Override
+            public List<Embedding> embedDocuments(String[] documents) { return null; }
+        };
+        registry.registerDense("my_custom", new EmbeddingFunctionRegistry.DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) {
+                return mockEf;
+            }
+        });
+        EmbeddingFunction resolved = registry.resolveDense(spec("my_custom"));
+        assertSame(mockEf, resolved);
+    }
+
+    @Test
+    public void testCustomRegistrySparseRegisterAndResolve() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        final SparseEmbeddingFunction mockSf = new SparseEmbeddingFunction() {
+            @Override
+            public SparseVector embedQuery(String query) { return null; }
+            @Override
+            public List<SparseVector> embedDocuments(List<String> documents) { return null; }
+        };
+        registry.registerSparse("my_sparse", new EmbeddingFunctionRegistry.SparseFactory() {
+            @Override
+            public SparseEmbeddingFunction create(Map<String, Object> config) {
+                return mockSf;
+            }
+        });
+        SparseEmbeddingFunction resolved = registry.resolveSparse(spec("my_sparse"));
+        assertSame(mockSf, resolved);
+    }
+
+    @Test
+    public void testCustomRegistryContentRegisterAndResolve() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        final ContentEmbeddingFunction mockCef = new ContentEmbeddingFunction() {
+            @Override
+            public List<Embedding> embedContents(List<Content> contents) { return null; }
+        };
+        registry.registerContent("my_content", new EmbeddingFunctionRegistry.ContentFactory() {
+            @Override
+            public ContentEmbeddingFunction create(Map<String, Object> config) {
+                return mockCef;
+            }
+        });
+        ContentEmbeddingFunction resolved = registry.resolveContent(spec("my_content"));
+        assertSame(mockCef, resolved);
+    }
+
+    @Test
+    public void testThreadSafety() throws Exception {
+        final EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        final int threadCount = 10;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        final AtomicInteger errors = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        String name = "provider_" + idx;
+                        registry.registerDense(name, new EmbeddingFunctionRegistry.DenseFactory() {
+                            @Override
+                            public EmbeddingFunction create(Map<String, Object> config) {
+                                return new EmbeddingFunction() {
+                                    @Override
+                                    public Embedding embedQuery(String query) { return null; }
+                                    @Override
+                                    public List<Embedding> embedDocuments(List<String> documents) { return null; }
+                                    @Override
+                                    public List<Embedding> embedDocuments(String[] documents) { return null; }
+                                };
+                            }
+                        });
+                        EmbeddingFunction ef = registry.resolveDense(spec(name));
+                        if (ef == null) {
+                            errors.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        errors.incrementAndGet();
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                }
+            });
+        }
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+        assertEquals("No errors expected during concurrent register/resolve", 0, errors.get());
+    }
+
+    @Test
+    public void testContentFallbackChain() throws EFException {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        final Embedding dummyEmbedding = new Embedding(new float[]{1.0f, 2.0f, 3.0f});
+        registry.registerDense("test_ef", new EmbeddingFunctionRegistry.DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) {
+                return new EmbeddingFunction() {
+                    @Override
+                    public Embedding embedQuery(String query) { return dummyEmbedding; }
+                    @Override
+                    public List<Embedding> embedDocuments(List<String> documents) {
+                        return Collections.singletonList(dummyEmbedding);
+                    }
+                    @Override
+                    public List<Embedding> embedDocuments(String[] documents) {
+                        return Collections.singletonList(dummyEmbedding);
+                    }
+                };
+            }
+        });
+        ContentEmbeddingFunction cef = registry.resolveContent(spec("test_ef"));
+        assertNotNull(cef);
+        // Verify the adapter works - embedding a text content should succeed
+        Embedding result = cef.embedContent(Content.text("hello"));
+        assertNotNull(result);
+        assertEquals(3, result.getDimensions());
+    }
+
+    @Test
+    public void testResolveNullSparseReturnsNull() {
+        assertNull(EmbeddingFunctionRegistry.getDefault().resolveSparse(null));
+    }
+
+    @Test
+    public void testResolveNullContentReturnsNull() {
+        assertNull(EmbeddingFunctionRegistry.getDefault().resolveContent(null));
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
@@ -228,4 +228,127 @@ public class TestEmbeddingFunctionRegistry {
     public void testResolveNullContentReturnsNull() {
         assertNull(EmbeddingFunctionRegistry.getDefault().resolveContent(null));
     }
+
+    @Test
+    public void testCustomRegistryResolvesCaseInsensitiveName() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        final EmbeddingFunction mockEf = new EmbeddingFunction() {
+            @Override
+            public Embedding embedQuery(String query) { return null; }
+            @Override
+            public List<Embedding> embedDocuments(List<String> documents) { return null; }
+            @Override
+            public List<Embedding> embedDocuments(String[] documents) { return null; }
+        };
+
+        registry.registerDense("MyProvider", new EmbeddingFunctionRegistry.DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) {
+                return mockEf;
+            }
+        });
+
+        assertSame(mockEf, registry.resolveDense(spec("MYPROVIDER")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterDenseRejectsNullName() {
+        new EmbeddingFunctionRegistry().registerDense(null, new EmbeddingFunctionRegistry.DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) {
+                return null;
+            }
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterSparseRejectsNullFactory() {
+        new EmbeddingFunctionRegistry().registerSparse("provider", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterContentRejectsBlankName() {
+        new EmbeddingFunctionRegistry().registerContent("   ", new EmbeddingFunctionRegistry.ContentFactory() {
+            @Override
+            public ContentEmbeddingFunction create(Map<String, Object> config) {
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testResolveDenseWrapsEFException() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        registry.registerDense("broken", new EmbeddingFunctionRegistry.DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) throws EFException {
+                throw new EFException("bad dense config");
+            }
+        });
+
+        try {
+            registry.resolveDense(spec("broken"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("Failed to create dense provider 'broken'"));
+            assertNotNull(e.getCause());
+        }
+    }
+
+    @Test
+    public void testResolveDenseWrapsRuntimeException() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        registry.registerDense("broken", new EmbeddingFunctionRegistry.DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) {
+                throw new IllegalStateException("boom");
+            }
+        });
+
+        try {
+            registry.resolveDense(spec("broken"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("Failed to create dense provider 'broken'"));
+            assertTrue(e.getCause() instanceof IllegalStateException);
+        }
+    }
+
+    @Test
+    public void testResolveContentWrapsRuntimeExceptionFromContentFactory() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        registry.registerContent("broken", new EmbeddingFunctionRegistry.ContentFactory() {
+            @Override
+            public ContentEmbeddingFunction create(Map<String, Object> config) {
+                throw new IllegalStateException("boom");
+            }
+        });
+
+        try {
+            registry.resolveContent(spec("broken"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("Failed to create content provider 'broken'"));
+            assertTrue(e.getCause() instanceof IllegalStateException);
+        }
+    }
+
+    @Test
+    public void testResolveContentWrapsRuntimeExceptionFromDenseFallback() {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        registry.registerDense("broken", new EmbeddingFunctionRegistry.DenseFactory() {
+            @Override
+            public EmbeddingFunction create(Map<String, Object> config) {
+                throw new IllegalStateException("boom");
+            }
+        });
+
+        try {
+            registry.resolveContent(spec("broken"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("via dense fallback"));
+            assertTrue(e.getCause() instanceof IllegalStateException);
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestEmbeddingFunctionRegistry.java
@@ -10,6 +10,7 @@ import tech.amikos.chromadb.v2.ChromaException;
 import tech.amikos.chromadb.v2.EmbeddingFunctionSpec;
 import tech.amikos.chromadb.v2.SparseVector;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -349,6 +350,24 @@ public class TestEmbeddingFunctionRegistry {
         } catch (ChromaException e) {
             assertTrue(e.getMessage().contains("via dense fallback"));
             assertTrue(e.getCause() instanceof IllegalStateException);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResolveDenseReportsUnavailableOptionalProvider() throws Exception {
+        EmbeddingFunctionRegistry registry = new EmbeddingFunctionRegistry();
+        Field field = EmbeddingFunctionRegistry.class.getDeclaredField("unavailableDenseProviders");
+        field.setAccessible(true);
+        Map<String, String> unavailable = (Map<String, String>) field.get(registry);
+        unavailable.put("google_genai", "requires optional dependency com.google.genai:google-genai on the classpath");
+
+        try {
+            registry.resolveDense(spec("google_genai"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("unavailable"));
+            assertTrue(e.getMessage().contains("google-genai"));
         }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
@@ -113,6 +113,22 @@ public class TestGeminiEmbeddingFunction {
     }
 
     @Test
+    public void testEmbedDocumentsArrayRejectsNullWithConfiguredModel() throws EFException {
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.model("custom-gemini-model")
+        );
+
+        try {
+            ef.embedDocuments((String[]) null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-gemini-model"));
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
     public void testToEmbeddingRejectsMissingEmbeddingsWithChromaException() throws Exception {
         GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
                 WithParam.apiKey("test-key"),

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
@@ -3,8 +3,13 @@ package tech.amikos.chromadb.embeddings;
 import org.junit.Test;
 import tech.amikos.chromadb.EFException;
 import tech.amikos.chromadb.embeddings.gemini.GeminiEmbeddingFunction;
+import tech.amikos.chromadb.v2.ChromaException;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -57,5 +62,106 @@ public class TestGeminiEmbeddingFunction {
     @Test
     public void testGeminiApiKeyEnvConstant() {
         assertEquals("GEMINI_API_KEY", GeminiEmbeddingFunction.GEMINI_API_KEY_ENV);
+    }
+
+    @Test
+    public void testEmbedQueryRejectsNullWithConfiguredModel() throws EFException {
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.model("custom-gemini-model")
+        );
+
+        try {
+            ef.embedQuery(null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-gemini-model"));
+            assertTrue(e.getMessage().contains("query must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsNullListWithConfiguredModel() throws EFException {
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.model("custom-gemini-model")
+        );
+
+        try {
+            ef.embedDocuments((List<String>) null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-gemini-model"));
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsNullElementWithIndex() throws EFException {
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.model("custom-gemini-model")
+        );
+
+        try {
+            ef.embedDocuments(Arrays.asList("doc1", null));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("custom-gemini-model"));
+            assertTrue(e.getMessage().contains("document at index 1 must not be null"));
+        }
+    }
+
+    @Test
+    public void testToEmbeddingRejectsMissingEmbeddingsWithChromaException() throws Exception {
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.model("custom-gemini-model")
+        );
+        Method method = GeminiEmbeddingFunction.class.getDeclaredMethod(
+                "toEmbedding",
+                com.google.genai.types.EmbedContentResponse.class,
+                String.class
+        );
+        method.setAccessible(true);
+
+        com.google.genai.types.EmbedContentResponse response = com.google.genai.types.EmbedContentResponse.builder()
+                .build();
+
+        try {
+            method.invoke(ef, response, "custom-gemini-model");
+            fail("Expected ChromaException");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof ChromaException);
+            assertTrue(e.getCause().getMessage().contains("Gemini returned no embeddings"));
+        }
+    }
+
+    @Test
+    public void testToEmbeddingRejectsMissingValuesWithChromaException() throws Exception {
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.model("custom-gemini-model")
+        );
+        Method method = GeminiEmbeddingFunction.class.getDeclaredMethod(
+                "toEmbedding",
+                com.google.genai.types.EmbedContentResponse.class,
+                String.class
+        );
+        method.setAccessible(true);
+
+        com.google.genai.types.ContentEmbedding contentEmbedding = com.google.genai.types.ContentEmbedding.builder()
+                .build();
+        com.google.genai.types.EmbedContentResponse response = com.google.genai.types.EmbedContentResponse.builder()
+                .embeddings(Collections.singletonList(contentEmbedding))
+                .build();
+
+        try {
+            method.invoke(ef, response, "custom-gemini-model");
+            fail("Expected ChromaException");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof ChromaException);
+            assertTrue(e.getCause().getMessage().contains("Gemini embedding has no values"));
+        }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestGeminiEmbeddingFunction.java
@@ -1,0 +1,61 @@
+package tech.amikos.chromadb.embeddings;
+
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.gemini.GeminiEmbeddingFunction;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for GeminiEmbeddingFunction.
+ *
+ * <p>These tests verify construction and configuration behavior.
+ * Actual API calls require a real Gemini API key and are not tested here.</p>
+ */
+public class TestGeminiEmbeddingFunction {
+
+    @Test
+    public void testConstructWithApiKey() throws EFException {
+        // Construction with explicit API key should not throw
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(WithParam.apiKey("test-key"));
+        assertNotNull(ef);
+    }
+
+    @Test
+    public void testDefaultModelName() throws Exception {
+        Field field = GeminiEmbeddingFunction.class.getDeclaredField("DEFAULT_MODEL_NAME");
+        field.setAccessible(true);
+        assertEquals("text-embedding-004", field.get(null));
+    }
+
+    @Test
+    public void testConstructWithCustomModel() throws EFException {
+        // Construction with custom model should not throw
+        GeminiEmbeddingFunction ef = new GeminiEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.model("custom-model")
+        );
+        assertNotNull(ef);
+    }
+
+    @Test
+    public void testApiKeyFromEnvThrowsWhenNotSet() {
+        // When GEMINI_API_KEY env var is not set, no-arg constructor should throw
+        try {
+            new GeminiEmbeddingFunction();
+            fail("Expected EFException when GEMINI_API_KEY is not set");
+        } catch (EFException e) {
+            assertTrue(
+                    "Expected message to mention GEMINI_API_KEY, got: " + e.getMessage(),
+                    e.getMessage().contains("GEMINI_API_KEY")
+            );
+        }
+    }
+
+    @Test
+    public void testGeminiApiKeyEnvConstant() {
+        assertEquals("GEMINI_API_KEY", GeminiEmbeddingFunction.GEMINI_API_KEY_ENV);
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestSparseEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestSparseEmbeddingFunction.java
@@ -1,0 +1,54 @@
+package tech.amikos.chromadb.embeddings;
+
+import org.junit.Test;
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TestSparseEmbeddingFunction {
+
+    @Test
+    public void testEmbedQueryReturnsVector() throws Exception {
+        SparseEmbeddingFunction ef = new SparseEmbeddingFunction() {
+            @Override
+            public SparseVector embedQuery(String query) {
+                return SparseVector.of(new int[]{1, 2}, new float[]{0.5f, 0.8f});
+            }
+
+            @Override
+            public List<SparseVector> embedDocuments(List<String> documents) {
+                return null;
+            }
+        };
+
+        SparseVector result = ef.embedQuery("test");
+        assertNotNull(result);
+        assertArrayEquals(new int[]{1, 2}, result.getIndices());
+        assertArrayEquals(new float[]{0.5f, 0.8f}, result.getValues(), 0.001f);
+    }
+
+    @Test
+    public void testEmbedDocumentsReturnsList() throws Exception {
+        SparseEmbeddingFunction ef = new SparseEmbeddingFunction() {
+            @Override
+            public SparseVector embedQuery(String query) {
+                return SparseVector.of(new int[]{0}, new float[]{1.0f});
+            }
+
+            @Override
+            public List<SparseVector> embedDocuments(List<String> documents) {
+                SparseVector[] results = new SparseVector[documents.size()];
+                for (int i = 0; i < documents.size(); i++) {
+                    results[i] = SparseVector.of(new int[]{i}, new float[]{1.0f});
+                }
+                return Arrays.asList(results);
+            }
+        };
+
+        List<SparseVector> results = ef.embedDocuments(Arrays.asList("a", "b"));
+        assertEquals(2, results.size());
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
@@ -177,6 +177,18 @@ public class TestVoyageEmbeddingFunction {
     }
 
     @Test
+    public void testEmbedDocumentsArrayRejectsNull() throws EFException {
+        VoyageEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments((String[]) null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
     public void testMissingApiKeyFailsFast() throws EFException {
         VoyageEmbeddingFunction ef = new VoyageEmbeddingFunction(WithParam.baseAPI(wireMockUrl()));
 
@@ -222,6 +234,24 @@ public class TestVoyageEmbeddingFunction {
         } catch (ChromaException e) {
             assertTrue(e.getMessage().contains("Voyage embedding failed"));
             assertNotNull(e.getCause());
+        }
+    }
+
+    @Test
+    public void testResponseItemWithoutEmbeddingFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":[{\"index\":0}],\"usage\":{\"total_tokens\":5}}")));
+
+        VoyageEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.singletonList("doc1"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("has no embedding"));
         }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
@@ -1,0 +1,141 @@
+package tech.amikos.chromadb.embeddings;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.Embedding;
+import tech.amikos.chromadb.embeddings.voyage.VoyageEmbeddingFunction;
+import tech.amikos.chromadb.v2.ChromaException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for VoyageEmbeddingFunction using WireMock to stub the Voyage API.
+ */
+public class TestVoyageEmbeddingFunction {
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+    private String wireMockUrl() {
+        return "http://localhost:" + wireMock.port() + "/v1/embeddings";
+    }
+
+    private VoyageEmbeddingFunction createFunction() throws EFException {
+        return new VoyageEmbeddingFunction(
+                WithParam.apiKey("test-key"),
+                WithParam.baseAPI(wireMockUrl())
+        );
+    }
+
+    @Test
+    public void testEmbedDocuments() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":[{\"embedding\":[0.1,0.2,0.3],\"index\":0},{\"embedding\":[0.4,0.5,0.6],\"index\":1}],\"usage\":{\"total_tokens\":10}}")));
+
+        VoyageEmbeddingFunction ef = createFunction();
+        List<Embedding> result = ef.embedDocuments(Arrays.asList("doc1", "doc2"));
+
+        assertEquals(2, result.size());
+        assertEquals(3, result.get(0).getDimensions());
+        assertEquals(0.1f, result.get(0).asArray()[0], 0.01f);
+        assertEquals(0.2f, result.get(0).asArray()[1], 0.01f);
+        assertEquals(0.3f, result.get(0).asArray()[2], 0.01f);
+    }
+
+    @Test
+    public void testEmbedQuery() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":[{\"embedding\":[0.7,0.8,0.9],\"index\":0}],\"usage\":{\"total_tokens\":5}}")));
+
+        VoyageEmbeddingFunction ef = createFunction();
+        Embedding result = ef.embedQuery("test query");
+
+        assertNotNull(result);
+        assertEquals(3, result.getDimensions());
+
+        // Verify request body contains input_type: "query"
+        verify(postRequestedFor(urlEqualTo("/v1/embeddings"))
+                .withRequestBody(containing("\"input_type\":\"query\"")));
+    }
+
+    @Test
+    public void testEmbedDocumentsInputType() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":[{\"embedding\":[0.1,0.2,0.3],\"index\":0}],\"usage\":{\"total_tokens\":5}}")));
+
+        VoyageEmbeddingFunction ef = createFunction();
+        ef.embedDocuments(Arrays.asList("doc1"));
+
+        // Verify request body contains input_type: "document"
+        verify(postRequestedFor(urlEqualTo("/v1/embeddings"))
+                .withRequestBody(containing("\"input_type\":\"document\"")));
+    }
+
+    @Test
+    public void testAuthHeader() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":[{\"embedding\":[0.1,0.2,0.3],\"index\":0}],\"usage\":{\"total_tokens\":5}}")));
+
+        VoyageEmbeddingFunction ef = createFunction();
+        ef.embedDocuments(Arrays.asList("doc1"));
+
+        // Verify Authorization header
+        verify(postRequestedFor(urlEqualTo("/v1/embeddings"))
+                .withHeader("Authorization", equalTo("Bearer test-key")));
+    }
+
+    @Test
+    public void testErrorResponse() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"unauthorized\"}")));
+
+        VoyageEmbeddingFunction ef = new VoyageEmbeddingFunction(
+                WithParam.apiKey("bad-key"),
+                WithParam.baseAPI(wireMockUrl())
+        );
+        try {
+            ef.embedDocuments(Arrays.asList("doc1"));
+            fail("Expected ChromaException for 401 response");
+        } catch (ChromaException e) {
+            assertTrue(
+                    "Expected message to mention Voyage, got: " + e.getMessage(),
+                    e.getMessage().contains("Voyage")
+            );
+        }
+    }
+
+    @Test
+    public void testApiKeyFromEnvThrowsWhenNotSet() {
+        try {
+            new VoyageEmbeddingFunction();
+            fail("Expected EFException when VOYAGE_API_KEY is not set");
+        } catch (EFException e) {
+            assertTrue(
+                    "Expected message to mention VOYAGE_API_KEY, got: " + e.getMessage(),
+                    e.getMessage().contains("VOYAGE_API_KEY")
+            );
+        }
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
@@ -9,6 +9,7 @@ import tech.amikos.chromadb.embeddings.voyage.VoyageEmbeddingFunction;
 import tech.amikos.chromadb.v2.ChromaException;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -136,6 +137,72 @@ public class TestVoyageEmbeddingFunction {
                     "Expected message to mention VOYAGE_API_KEY, got: " + e.getMessage(),
                     e.getMessage().contains("VOYAGE_API_KEY")
             );
+        }
+    }
+
+    @Test
+    public void testEmbedQueryRejectsNull() throws EFException {
+        VoyageEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedQuery(null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("query must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsNull() throws EFException {
+        VoyageEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments((List<String>) null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmbedDocumentsRejectsEmptyList() throws EFException {
+        VoyageEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Collections.<String>emptyList());
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("documents must not be empty"));
+        }
+    }
+
+    @Test
+    public void testMissingApiKeyFailsFast() throws EFException {
+        VoyageEmbeddingFunction ef = new VoyageEmbeddingFunction(WithParam.baseAPI(wireMockUrl()));
+
+        try {
+            ef.embedDocuments(Arrays.asList("doc1"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("API key must not be null or empty"));
+        }
+    }
+
+    @Test
+    public void testEmptyResponseBodyFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("")));
+
+        VoyageEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Arrays.asList("doc1"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("response body was empty"));
         }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/TestVoyageEmbeddingFunction.java
@@ -205,4 +205,23 @@ public class TestVoyageEmbeddingFunction {
             assertTrue(e.getMessage().contains("response body was empty"));
         }
     }
+
+    @Test
+    public void testMalformedJsonFailsDescriptively() throws EFException {
+        stubFor(post(urlEqualTo("/v1/embeddings"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{not-json")));
+
+        VoyageEmbeddingFunction ef = createFunction();
+
+        try {
+            ef.embedDocuments(Arrays.asList("doc1"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("Voyage embedding failed"));
+            assertNotNull(e.getCause());
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
@@ -123,4 +123,19 @@ public class TestBM25EmbeddingFunction {
             assertTrue(e.getMessage().contains("documents must not be empty"));
         }
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullTokenizerRejected() {
+        new BM25EmbeddingFunction(null, 100.0f);
+    }
+
+    @Test
+    public void testNullDocumentElementThrows() throws EFException {
+        try {
+            ef.embedDocuments(Arrays.asList("doc1", null, "doc3"));
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("document at index 1 must not be null"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
@@ -2,9 +2,11 @@ package tech.amikos.chromadb.embeddings.bm25;
 
 import org.junit.Test;
 import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.v2.ChromaException;
 import tech.amikos.chromadb.v2.SparseVector;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -52,9 +54,13 @@ public class TestBM25EmbeddingFunction {
     }
 
     @Test
-    public void testNullTextReturnsEmptySparse() throws EFException {
-        SparseVector result = ef.embedQuery(null);
-        assertEquals("Null text should produce 0 indices", 0, result.getIndices().length);
+    public void testNullTextThrows() throws EFException {
+        try {
+            ef.embedQuery(null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("query must not be null"));
+        }
     }
 
     @Test
@@ -95,6 +101,26 @@ public class TestBM25EmbeddingFunction {
         float[] values = result.getValues();
         for (float v : values) {
             assertTrue("BM25 scores should be positive: " + v, v > 0);
+        }
+    }
+
+    @Test
+    public void testNullDocumentsThrow() throws EFException {
+        try {
+            ef.embedDocuments(null);
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testEmptyDocumentsThrow() throws EFException {
+        try {
+            ef.embedDocuments(Collections.<String>emptyList());
+            fail("Expected ChromaException");
+        } catch (ChromaException e) {
+            assertTrue(e.getMessage().contains("documents must not be empty"));
         }
     }
 }

--- a/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25EmbeddingFunction.java
@@ -1,0 +1,100 @@
+package tech.amikos.chromadb.embeddings.bm25;
+
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.v2.SparseVector;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for BM25EmbeddingFunction.
+ */
+public class TestBM25EmbeddingFunction {
+
+    private final BM25EmbeddingFunction ef = new BM25EmbeddingFunction();
+
+    @Test
+    public void testEmbedQueryReturnsVector() throws EFException {
+        SparseVector result = ef.embedQuery("the quick brown fox jumps over the lazy dog");
+        assertNotNull("Result should not be null", result);
+        assertTrue("Should have indices", result.getIndices().length > 0);
+        assertTrue("Should have values", result.getValues().length > 0);
+        assertEquals("Indices and values should have same length",
+                result.getIndices().length, result.getValues().length);
+    }
+
+    @Test
+    public void testIndicesSorted() throws EFException {
+        SparseVector result = ef.embedQuery("the quick brown fox jumps over the lazy dog");
+        int[] indices = result.getIndices();
+        for (int i = 1; i < indices.length; i++) {
+            assertTrue("Indices should be sorted ascending: " + indices[i - 1] + " <= " + indices[i],
+                    indices[i - 1] <= indices[i]);
+        }
+    }
+
+    @Test
+    public void testEmbedDocuments() throws EFException {
+        List<SparseVector> results = ef.embedDocuments(Arrays.asList("hello world", "foo bar"));
+        assertEquals("Should return 2 vectors", 2, results.size());
+        assertNotNull("First vector should not be null", results.get(0));
+        assertNotNull("Second vector should not be null", results.get(1));
+    }
+
+    @Test
+    public void testEmptyTextReturnsEmptySparse() throws EFException {
+        SparseVector result = ef.embedQuery("");
+        assertEquals("Empty text should produce 0 indices", 0, result.getIndices().length);
+        assertEquals("Empty text should produce 0 values", 0, result.getValues().length);
+    }
+
+    @Test
+    public void testNullTextReturnsEmptySparse() throws EFException {
+        SparseVector result = ef.embedQuery(null);
+        assertEquals("Null text should produce 0 indices", 0, result.getIndices().length);
+    }
+
+    @Test
+    public void testDeterministic() throws EFException {
+        String input = "deterministic test input";
+        SparseVector result1 = ef.embedQuery(input);
+        SparseVector result2 = ef.embedQuery(input);
+        assertArrayEquals("Same input should produce same indices", result1.getIndices(), result2.getIndices());
+        assertArrayEquals("Same input should produce same values", result1.getValues(), result2.getValues(), 0.0001f);
+    }
+
+    @Test
+    public void testCustomAvgDocLen() throws EFException {
+        BM25EmbeddingFunction customEf = new BM25EmbeddingFunction(new BM25Tokenizer(), 100.0f);
+        SparseVector defaultResult = ef.embedQuery("hello world example text for testing");
+        SparseVector customResult = customEf.embedQuery("hello world example text for testing");
+
+        // Same indices (same tokens) but different scores due to different avgDocLen
+        assertArrayEquals("Should have same indices",
+                defaultResult.getIndices(), customResult.getIndices());
+
+        // Values should differ because avgDocLen changes BM25 normalization
+        boolean anyDiffer = false;
+        float[] defaultValues = defaultResult.getValues();
+        float[] customValues = customResult.getValues();
+        for (int i = 0; i < defaultValues.length; i++) {
+            if (Math.abs(defaultValues[i] - customValues[i]) > 0.0001f) {
+                anyDiffer = true;
+                break;
+            }
+        }
+        assertTrue("Different avgDocLen should produce different scores", anyDiffer);
+    }
+
+    @Test
+    public void testPositiveValues() throws EFException {
+        SparseVector result = ef.embedQuery("test document with multiple words");
+        float[] values = result.getValues();
+        for (float v : values) {
+            assertTrue("BM25 scores should be positive: " + v, v > 0);
+        }
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25Tokenizer.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestBM25Tokenizer.java
@@ -1,0 +1,82 @@
+package tech.amikos.chromadb.embeddings.bm25;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for BM25Tokenizer pipeline.
+ */
+public class TestBM25Tokenizer {
+
+    private final BM25Tokenizer tokenizer = new BM25Tokenizer();
+
+    @Test
+    public void testStopWordFiltering() {
+        List<String> tokens = tokenizer.tokenize("The quick brown fox");
+        // "the" is a stop word and should be filtered
+        assertFalse("'the' should be filtered as a stop word",
+                tokens.contains("the"));
+        assertTrue("Result should contain stemmed tokens", tokens.size() > 0);
+    }
+
+    @Test
+    public void testLowercaseAndStrip() {
+        List<String> tokens = tokenizer.tokenize("Hello!!! World???");
+        // All tokens should be lowercase, non-alphanumeric stripped
+        for (String token : tokens) {
+            assertEquals("Tokens should be lowercase", token.toLowerCase(), token);
+            assertFalse("Tokens should not contain '!'", token.contains("!"));
+            assertFalse("Tokens should not contain '?'", token.contains("?"));
+        }
+        assertTrue("Should produce tokens", tokens.size() > 0);
+    }
+
+    @Test
+    public void testEmptyString() {
+        List<String> tokens = tokenizer.tokenize("");
+        assertTrue("Empty string should produce empty list", tokens.isEmpty());
+    }
+
+    @Test
+    public void testNullString() {
+        List<String> tokens = tokenizer.tokenize(null);
+        assertTrue("Null string should produce empty list", tokens.isEmpty());
+    }
+
+    @Test
+    public void testStemming() {
+        List<String> tokens = tokenizer.tokenize("running runs");
+        // Both "running" and "runs" should stem to "run" (Snowball English)
+        assertEquals("Both words should produce tokens", 2, tokens.size());
+        assertEquals("First token should be stemmed to 'run'", "run", tokens.get(0));
+        assertEquals("Second token should be stemmed to 'run'", "run", tokens.get(1));
+    }
+
+    @Test
+    public void testMaxTokenLength() {
+        // Create tokenizer with maxLength=5
+        BM25Tokenizer shortTokenizer = new BM25Tokenizer(
+                Collections.<String>emptySet(), 5);
+        List<String> tokens = shortTokenizer.tokenize("abcdef short");
+        // "abcdef" (6 chars) should be filtered, "short" (5 chars) should remain
+        assertEquals("Only token within max length should remain", 1, tokens.size());
+    }
+
+    @Test
+    public void testOnlyStopWords() {
+        List<String> tokens = tokenizer.tokenize("the a an");
+        assertTrue("All-stop-word input should produce empty list", tokens.isEmpty());
+    }
+
+    @Test
+    public void testStopWordsCount() {
+        assertEquals("Default stop words should have 179 entries", 179, BM25StopWords.DEFAULT.size());
+        assertTrue("Should contain 'ourselves'", BM25StopWords.DEFAULT.contains("ourselves"));
+        assertTrue("Should contain 'the'", BM25StopWords.DEFAULT.contains("the"));
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestMurmur3.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/bm25/TestMurmur3.java
@@ -1,0 +1,62 @@
+package tech.amikos.chromadb.embeddings.bm25;
+
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for Murmur3 x86 32-bit hash implementation.
+ */
+public class TestMurmur3 {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    @Test
+    public void testHelloHash() {
+        // Known test vector: mmh3.hash("hello", 0, signed=True) in Python
+        int hash = Murmur3.hash32("hello".getBytes(UTF_8), 0);
+        assertEquals("Murmur3 hash of 'hello' with seed 0", 613153351, hash);
+    }
+
+    @Test
+    public void testEmptyHash() {
+        // Empty input with seed 0: fmix32(0 ^ 0) = fmix32(0) = 0
+        int hash = Murmur3.hash32(new byte[0], 0);
+        assertEquals("Murmur3 hash of empty input with seed 0", 0, hash);
+    }
+
+    @Test
+    public void testKnownVectorTest() {
+        // Another known vector: "test" with seed 0
+        int hash = Murmur3.hash32("test".getBytes(UTF_8), 0);
+        // Murmur3 x86 32-bit hash of "test" with seed 0 is a known value
+        // Verify it's deterministic and non-zero
+        assertNotEquals("Hash of 'test' should not be 0", 0, hash);
+    }
+
+    @Test
+    public void testSeedZeroDifferentFromSeed42() {
+        byte[] data = "a".getBytes(UTF_8);
+        int hashSeed0 = Murmur3.hash32(data, 0);
+        int hashSeed42 = Murmur3.hash32(data, 42);
+        assertNotEquals("Different seeds should produce different hashes", hashSeed0, hashSeed42);
+    }
+
+    @Test
+    public void testDeterministic() {
+        byte[] data = "deterministic".getBytes(UTF_8);
+        int hash1 = Murmur3.hash32(data, 0);
+        int hash2 = Murmur3.hash32(data, 0);
+        assertEquals("Same input should always produce same hash", hash1, hash2);
+    }
+
+    @Test
+    public void testMultiByteBlocks() {
+        // Test input that spans multiple 4-byte blocks plus tail
+        // "abcdefghij" = 10 bytes = 2 full blocks + 2 tail bytes
+        int hash = Murmur3.hash32("abcdefghij".getBytes(UTF_8), 0);
+        assertNotEquals("Multi-block input should produce non-zero hash", 0, hash);
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
@@ -37,6 +37,16 @@ public class TestContentTypes {
         Content.builder().build();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testContentTextNullThrows() {
+        Content.text(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testContentBuilderNullPartThrows() {
+        Content.builder().part(null);
+    }
+
     @Test
     public void testPartTextFactory() {
         Part p = Part.text("t");
@@ -79,6 +89,11 @@ public class TestContentTypes {
         assertNull(s.getFilePath());
         assertNull(s.getBase64Data());
         assertNull(s.getBytes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBinarySourceFromUrlNullThrows() {
+        BinarySource.fromUrl(null);
     }
 
     @Test

--- a/src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
@@ -1,0 +1,150 @@
+package tech.amikos.chromadb.embeddings.content;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestContentTypes {
+
+    @Test
+    public void testContentTextFactory() {
+        Content c = Content.text("hello");
+        assertEquals(1, c.getParts().size());
+        assertEquals(Modality.TEXT, c.getParts().get(0).getModality());
+        assertEquals("hello", c.getParts().get(0).getText());
+        assertNull(c.getIntent());
+    }
+
+    @Test
+    public void testContentBuilderMultipleParts() {
+        Content c = Content.builder()
+                .part(Part.text("hi"))
+                .part(Part.image(BinarySource.fromUrl("http://img")))
+                .intent(Intent.RETRIEVAL_DOCUMENT)
+                .build();
+        assertEquals(2, c.getParts().size());
+        assertEquals(Intent.RETRIEVAL_DOCUMENT, c.getIntent());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testContentPartsUnmodifiable() {
+        Content c = Content.text("a");
+        c.getParts().add(Part.text("b"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testContentBuilderEmptyPartsThrows() {
+        Content.builder().build();
+    }
+
+    @Test
+    public void testPartTextFactory() {
+        Part p = Part.text("t");
+        assertEquals(Modality.TEXT, p.getModality());
+        assertEquals("t", p.getText());
+        assertNull(p.getSource());
+    }
+
+    @Test
+    public void testPartImageFactory() {
+        Part p = Part.image(BinarySource.fromUrl("u"));
+        assertEquals(Modality.IMAGE, p.getModality());
+        assertNotNull(p.getSource());
+        assertNull(p.getText());
+    }
+
+    @Test
+    public void testPartAudioFactory() {
+        Part p = Part.audio(BinarySource.fromUrl("u"));
+        assertEquals(Modality.AUDIO, p.getModality());
+        assertNotNull(p.getSource());
+    }
+
+    @Test
+    public void testPartVideoFactory() {
+        Part p = Part.video(BinarySource.fromUrl("u"));
+        assertEquals(Modality.VIDEO, p.getModality());
+        assertNotNull(p.getSource());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPartTextNullThrows() {
+        Part.text(null);
+    }
+
+    @Test
+    public void testBinarySourceFromUrl() {
+        BinarySource s = BinarySource.fromUrl("http://x");
+        assertEquals("http://x", s.getUrl());
+        assertNull(s.getFilePath());
+        assertNull(s.getBase64Data());
+        assertNull(s.getBytes());
+    }
+
+    @Test
+    public void testBinarySourceFromFile() {
+        BinarySource s = BinarySource.fromFile("/tmp/img.png");
+        assertEquals("/tmp/img.png", s.getFilePath());
+        assertNull(s.getUrl());
+    }
+
+    @Test
+    public void testBinarySourceFromBase64() {
+        BinarySource s = BinarySource.fromBase64("AQID");
+        assertEquals("AQID", s.getBase64Data());
+    }
+
+    @Test
+    public void testBinarySourceFromBytesDefensiveCopy() {
+        byte[] original = new byte[]{1, 2, 3};
+        BinarySource s = BinarySource.fromBytes(original);
+        byte[] first = s.getBytes();
+        assertArrayEquals(new byte[]{1, 2, 3}, first);
+
+        // Mutate returned array
+        first[0] = 99;
+        // Verify source is unchanged
+        assertArrayEquals(new byte[]{1, 2, 3}, s.getBytes());
+    }
+
+    @Test
+    public void testModalityFromValue() {
+        assertEquals(Modality.TEXT, Modality.fromValue("text"));
+        assertEquals(Modality.IMAGE, Modality.fromValue("image"));
+        assertEquals(Modality.AUDIO, Modality.fromValue("audio"));
+        assertEquals(Modality.VIDEO, Modality.fromValue("video"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testModalityFromValueInvalid() {
+        Modality.fromValue("bogus");
+    }
+
+    @Test
+    public void testIntentFromValue() {
+        assertEquals(Intent.RETRIEVAL_DOCUMENT, Intent.fromValue("retrieval_document"));
+        assertEquals(Intent.RETRIEVAL_QUERY, Intent.fromValue("retrieval_query"));
+        assertEquals(Intent.CLASSIFICATION, Intent.fromValue("classification"));
+        assertEquals(Intent.CLUSTERING, Intent.fromValue("clustering"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIntentFromValueInvalid() {
+        Intent.fromValue("bogus");
+    }
+
+    @Test
+    public void testContentEquality() {
+        Content a = Content.text("same");
+        Content b = Content.text("same");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testContentInequality() {
+        Content a = Content.text("hello");
+        Content b = Content.text("world");
+        assertNotEquals(a, b);
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
+++ b/src/test/java/tech/amikos/chromadb/embeddings/content/TestContentTypes.java
@@ -103,6 +103,11 @@ public class TestContentTypes {
         assertNull(s.getUrl());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testBinarySourceFromFileNullThrows() {
+        BinarySource.fromFile(null);
+    }
+
     @Test
     public void testBinarySourceFromBase64() {
         BinarySource s = BinarySource.fromBase64("AQID");
@@ -120,6 +125,11 @@ public class TestContentTypes {
         first[0] = 99;
         // Verify source is unchanged
         assertArrayEquals(new byte[]{1, 2, 3}, s.getBytes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBinarySourceFromBytesNullThrows() {
+        BinarySource.fromBytes(null);
     }
 
     @Test

--- a/src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
@@ -137,4 +137,17 @@ public class TestCohereRerankingFunction {
             assertTrue(e.getMessage().contains("response did not contain results"));
         }
     }
+
+    @Test
+    public void testEmptyDocumentsRejected() throws EFException {
+        CohereRerankingFunction reranker = new CohereRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", Arrays.<String>asList());
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("documents must not be empty"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
@@ -1,0 +1,83 @@
+package tech.amikos.chromadb.reranking;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.reranking.cohere.CohereRerankingFunction;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.*;
+
+public class TestCohereRerankingFunction {
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+    private String wireMockBaseUrl;
+
+    @Before
+    public void setUp() {
+        wireMockBaseUrl = "http://localhost:" + wireMock.port() + "/v2/rerank";
+    }
+
+    @Test
+    public void testRerankSuccess() throws EFException {
+        stubFor(post(urlEqualTo("/v2/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"index\":1,\"relevance_score\":0.95},{\"index\":0,\"relevance_score\":0.72}]}")));
+
+        CohereRerankingFunction reranker = new CohereRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+        List<RerankResult> results = reranker.rerank("query", Arrays.asList("doc0", "doc1"));
+
+        assertEquals(2, results.size());
+        // Sorted by descending score
+        assertEquals(1, results.get(0).getIndex());
+        assertEquals(0.95, results.get(0).getScore(), 0.0001);
+        assertEquals(0, results.get(1).getIndex());
+        assertEquals(0.72, results.get(1).getScore(), 0.0001);
+    }
+
+    @Test
+    public void testRerankAuthFailure() throws EFException {
+        stubFor(post(urlEqualTo("/v2/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\":\"invalid api key\"}")));
+
+        CohereRerankingFunction reranker = new CohereRerankingFunction(
+                WithParam.apiKey("bad-key"), WithParam.baseAPI(wireMockBaseUrl));
+        try {
+            reranker.rerank("query", Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("401"));
+        }
+    }
+
+    @Test
+    public void testRequestContainsAuthHeader() throws EFException {
+        stubFor(post(urlEqualTo("/v2/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"index\":0,\"relevance_score\":0.5}]}")));
+
+        CohereRerankingFunction reranker = new CohereRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+        reranker.rerank("query", Arrays.asList("doc0"));
+
+        verify(postRequestedFor(urlEqualTo("/v2/rerank"))
+                .withHeader("Authorization", equalTo("Bearer test-key")));
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestCohereRerankingFunction.java
@@ -80,4 +80,61 @@ public class TestCohereRerankingFunction {
         verify(postRequestedFor(urlEqualTo("/v2/rerank"))
                 .withHeader("Authorization", equalTo("Bearer test-key")));
     }
+
+    @Test
+    public void testMissingApiKeyFailsFast() throws EFException {
+        CohereRerankingFunction reranker = new CohereRerankingFunction(WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("API key must not be null or empty"));
+        }
+    }
+
+    @Test
+    public void testNullQueryRejected() throws EFException {
+        CohereRerankingFunction reranker = new CohereRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank(null, Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("query must not be null"));
+        }
+    }
+
+    @Test
+    public void testNullDocumentsRejected() throws EFException {
+        CohereRerankingFunction reranker = new CohereRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", null);
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testMissingResultsRejected() throws EFException {
+        stubFor(post(urlEqualTo("/v2/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
+
+        CohereRerankingFunction reranker = new CohereRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("response did not contain results"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
@@ -1,0 +1,82 @@
+package tech.amikos.chromadb.reranking;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import tech.amikos.chromadb.EFException;
+import tech.amikos.chromadb.embeddings.WithParam;
+import tech.amikos.chromadb.reranking.jina.JinaRerankingFunction;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.*;
+
+public class TestJinaRerankingFunction {
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+    private String wireMockBaseUrl;
+
+    @Before
+    public void setUp() {
+        wireMockBaseUrl = "http://localhost:" + wireMock.port() + "/v1/rerank";
+    }
+
+    @Test
+    public void testRerankSuccess() throws EFException {
+        stubFor(post(urlEqualTo("/v1/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"index\":0,\"relevance_score\":0.9},{\"index\":1,\"relevance_score\":0.3}]}")));
+
+        JinaRerankingFunction reranker = new JinaRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+        List<RerankResult> results = reranker.rerank("query", Arrays.asList("doc0", "doc1"));
+
+        assertEquals(2, results.size());
+        assertEquals(0, results.get(0).getIndex());
+        assertEquals(0.9, results.get(0).getScore(), 0.0001);
+        assertEquals(1, results.get(1).getIndex());
+        assertEquals(0.3, results.get(1).getScore(), 0.0001);
+    }
+
+    @Test
+    public void testRerankServerError() throws EFException {
+        stubFor(post(urlEqualTo("/v1/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\":\"internal server error\"}")));
+
+        JinaRerankingFunction reranker = new JinaRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+        try {
+            reranker.rerank("query", Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("500"));
+        }
+    }
+
+    @Test
+    public void testRequestContainsModel() throws EFException {
+        stubFor(post(urlEqualTo("/v1/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"results\":[{\"index\":0,\"relevance_score\":0.5}]}")));
+
+        JinaRerankingFunction reranker = new JinaRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+        reranker.rerank("query", Arrays.asList("doc0"));
+
+        verify(postRequestedFor(urlEqualTo("/v1/rerank"))
+                .withRequestBody(containing("\"model\":\"jina-reranker-v2-base-multilingual\"")));
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
@@ -136,4 +136,17 @@ public class TestJinaRerankingFunction {
             assertTrue(e.getMessage().contains("response did not contain results"));
         }
     }
+
+    @Test
+    public void testEmptyDocumentsRejected() throws EFException {
+        JinaRerankingFunction reranker = new JinaRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", Arrays.<String>asList());
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("documents must not be empty"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestJinaRerankingFunction.java
@@ -79,4 +79,61 @@ public class TestJinaRerankingFunction {
         verify(postRequestedFor(urlEqualTo("/v1/rerank"))
                 .withRequestBody(containing("\"model\":\"jina-reranker-v2-base-multilingual\"")));
     }
+
+    @Test
+    public void testMissingApiKeyFailsFast() throws EFException {
+        JinaRerankingFunction reranker = new JinaRerankingFunction(WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("API key must not be null or empty"));
+        }
+    }
+
+    @Test
+    public void testNullQueryRejected() throws EFException {
+        JinaRerankingFunction reranker = new JinaRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank(null, Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("query must not be null"));
+        }
+    }
+
+    @Test
+    public void testNullDocumentsRejected() throws EFException {
+        JinaRerankingFunction reranker = new JinaRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", null);
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("documents must not be null"));
+        }
+    }
+
+    @Test
+    public void testMissingResultsRejected() throws EFException {
+        stubFor(post(urlEqualTo("/v1/rerank"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
+
+        JinaRerankingFunction reranker = new JinaRerankingFunction(
+                WithParam.apiKey("test-key"), WithParam.baseAPI(wireMockBaseUrl));
+
+        try {
+            reranker.rerank("query", Arrays.asList("doc0"));
+            fail("Expected EFException");
+        } catch (EFException e) {
+            assertTrue(e.getMessage().contains("response did not contain results"));
+        }
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java
@@ -42,4 +42,9 @@ public class TestRerankResult {
         assertTrue(str.contains("index=2"));
         assertTrue(str.contains("score=0.85"));
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeIndexRejected() {
+        RerankResult.of(-1, 0.1);
+    }
 }

--- a/src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java
+++ b/src/test/java/tech/amikos/chromadb/reranking/TestRerankResult.java
@@ -1,0 +1,45 @@
+package tech.amikos.chromadb.reranking;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestRerankResult {
+
+    @Test
+    public void testOfAndGetters() {
+        RerankResult result = RerankResult.of(2, 0.85);
+        assertEquals(2, result.getIndex());
+        assertEquals(0.85, result.getScore(), 0.0001);
+    }
+
+    @Test
+    public void testEquality() {
+        RerankResult a = RerankResult.of(1, 0.5);
+        RerankResult b = RerankResult.of(1, 0.5);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testInequality() {
+        RerankResult a = RerankResult.of(1, 0.5);
+        RerankResult b = RerankResult.of(2, 0.5);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testInequalityByScore() {
+        RerankResult a = RerankResult.of(1, 0.5);
+        RerankResult b = RerankResult.of(1, 0.9);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testToString() {
+        RerankResult result = RerankResult.of(2, 0.85);
+        String str = result.toString();
+        assertTrue(str.contains("index=2"));
+        assertTrue(str.contains("score=0.85"));
+    }
+}

--- a/src/test/java/tech/amikos/chromadb/v2/ChromaHttpCollectionTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/ChromaHttpCollectionTest.java
@@ -1549,7 +1549,7 @@ public class ChromaHttpCollectionTest {
             col.query().queryTexts("hello").execute();
             fail("Expected ChromaException");
         } catch (ChromaException e) {
-            assertTrue(e.getMessage().contains("Failed to initialize embedding function provider 'openai'"));
+            assertTrue(e.getMessage().contains("openai"));
             assertNotNull(e.getCause());
         }
     }

--- a/src/test/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolverTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/EmbeddingFunctionResolverTest.java
@@ -107,6 +107,8 @@ public class EmbeddingFunctionResolverTest {
         } catch (ChromaException e) {
             assertTrue(e.getMessage().contains("consistent_hash"));
             assertTrue(e.getMessage().contains("queryEmbeddings"));
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof UnsupportedEmbeddingProviderException);
             return;
         }
         throw new AssertionError("Expected ChromaException");

--- a/src/test/java/tech/amikos/chromadb/v2/SchemaAndQueryTextsIntegrationTest.java
+++ b/src/test/java/tech/amikos/chromadb/v2/SchemaAndQueryTextsIntegrationTest.java
@@ -215,7 +215,8 @@ public class SchemaAndQueryTextsIntegrationTest extends AbstractChromaIntegratio
             col.query().queryTexts("hello").execute();
             fail("Expected ChromaException");
         } catch (ChromaException e) {
-            assertTrue(e.getMessage().contains("Failed to initialize embedding function provider 'openai'"));
+            assertTrue("Expected error about provider 'openai', got: " + e.getMessage(),
+                    e.getMessage().contains("openai"));
             assertNotNull(e.getCause());
         }
     }


### PR DESCRIPTION
## Summary

**Phase 4: Embedding Ecosystem**
**Goal:** Expand the embedding ecosystem with sparse/content interfaces, reranking functions, additional dense providers, and an auto-wiring registry.
**Status:** Verified (UAT 9/9 passed), reviewed (5 rounds of automated review)

This PR adds a complete embedding ecosystem to the Java client: sparse and multimodal embedding interfaces, reranking support, three new dense providers, two sparse providers, and a central registry for auto-wiring providers from server-side collection config.

## Changes

### Plan 04-01: Embedding Foundation Interfaces
Sparse and multimodal content embedding interfaces with bidirectional adapters.

**Key files created:**
- `SparseEmbeddingFunction` — interface for sparse vector providers (BM25, SPLADE)
- `ContentEmbeddingFunction` — interface for multimodal embedding providers
- `Content`, `Part`, `BinarySource` — value types for multimodal content
- `Modality`, `Intent` — enums for content typing and embedding intent
- `TextEmbeddingAdapter`, `ContentToTextAdapter` — bidirectional adapters

### Plan 04-02: Reranking Interface and Providers
Reranking function interface with Cohere and Jina implementations.

**Key files created:**
- `RerankingFunction` — interface for document reranking
- `RerankResult` — immutable value type for ranked results
- `CohereRerankingFunction` — Cohere v2/rerank endpoint
- `JinaRerankingFunction` — Jina v1/rerank endpoint

### Plan 04-03: Dense Embedding Providers
Three new dense embedding providers: Gemini, Bedrock, and Voyage.

**Key files created:**
- `GeminiEmbeddingFunction` — via Google GenAI SDK (optional dependency)
- `BedrockEmbeddingFunction` — via AWS SDK BedrockRuntime (optional dependency)
- `VoyageEmbeddingFunction` — via OkHttp REST calls

### Plan 04-04: Sparse Embedding Providers
BM25 local sparse embeddings and ChromaCloud SPLADE remote sparse embeddings.

**Key files created:**
- `BM25EmbeddingFunction` — local tokenize → stem → hash → TF-IDF pipeline
- `BM25Tokenizer`, `Murmur3`, `BM25StopWords` — pipeline components
- `ChromaCloudSpladeEmbeddingFunction` — remote SPLADE via Chroma Cloud API

### Plan 04-05: EmbeddingFunctionRegistry
Central registry with three factory maps (dense, sparse, content) and auto-wiring from collection config.

**Key files created:**
- `EmbeddingFunctionRegistry` — singleton registry with provider factory maps
- `UnsupportedEmbeddingProviderException` — typed exception for unknown providers

**Key files modified:**
- `EmbeddingFunctionResolver` — now delegates to registry instead of hardcoded dispatch

## Requirements Addressed

- **EMB-05:** Sparse embedding interfaces and providers
- **EMB-06:** Multimodal content embedding interfaces
- **EMB-07:** Additional dense embedding providers (Gemini, Bedrock, Voyage)
- **EMB-08:** Embedding function registry with auto-wiring
- **RERANK-01:** Reranking interface and providers

## Verification

- [x] UAT: 9/9 tests passed
- [x] 5 rounds of automated code review (code quality, error handling, type design, test coverage)
- [x] All 114+ unit tests pass
- [x] Java 8 compatibility maintained
- [x] Thread-safe BM25Tokenizer and EmbeddingFunctionRegistry
- [x] Defensive response DTO parsing with index-context error messages
- [x] Input validation on all public API methods (null query/documents, missing API keys)

## Test Plan

- [ ] CI passes (build + all tests)
- [ ] Verify optional dependencies (Gemini, Bedrock) don't break builds without their SDKs
- [ ] Spot-check: BM25 embedding produces deterministic sparse vectors
- [ ] Spot-check: Registry resolves built-in providers by name